### PR TITLE
Refactor/blocks

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -64,9 +64,6 @@ impl BlockHeader {
 
 impl BlockBody {
     /// Creates a new `BlockBody`
-    ///
-    /// * `creator` - `secp256k1::PublicKey` of the block creator
-    /// * `previous_block_hash` - Previous block hash in bytes
     pub fn new() -> Self {
         BlockBody {
             transactions: vec![],

--- a/src/block.rs
+++ b/src/block.rs
@@ -10,7 +10,7 @@ pub struct Block {
     header: BlockHeader,
     /// The body and content of the block object
     body: BlockBody,
-    /// Mmemoized hash of the block
+    /// Memoized hash of the block
     hash: Option<[u8; 32]>,
 }
 
@@ -47,7 +47,7 @@ impl BlockHeader {
     /// Creates a new `BlockHeader`
     ///
     /// * `creator` - `secp256k1::PublicKey` of the block creator
-    /// * `previous_block_hash` - Parent block hash in bytes
+    /// * `previous_block_hash` - Previous block hash in bytes
     pub fn new(creator: PublicKey, previous_block_hash: [u8; 32]) -> Self {
         BlockHeader {
             id: 0,
@@ -160,8 +160,9 @@ impl Block {
     }
 
     /// Converts our blockhash from a byte array into a hex string
-    pub fn hash_as_hex(&mut self) -> String {
-        hex::encode(&self.hash())
+    pub fn hash_as_hex(&self) -> String {
+        let hash = self.hash.unwrap_or_else(|| self.hash());
+        hex::encode(hash)
     }
 
     /// Sets the `Block`s list of `Transaction`s

--- a/src/block.rs
+++ b/src/block.rs
@@ -22,7 +22,7 @@ pub struct BlockHeader {
     /// Block timestamp
     timestamp: u64,
     /// Byte array hash of the previous block in the chain
-    parent_hash: [u8; 32],
+    previous_block_hash: [u8; 32],
     /// `Publickey` of the block creator
     creator: PublicKey,
     /// `BurnFee` containing the fees paid to produce the block
@@ -47,12 +47,12 @@ impl BlockHeader {
     /// Creates a new `BlockHeader`
     ///
     /// * `creator` - `secp256k1::PublicKey` of the block creator
-    /// * `parent_hash` - Parent block hash in bytes
-    pub fn new(creator: PublicKey, parent_hash: [u8; 32]) -> Self {
+    /// * `previous_block_hash` - Parent block hash in bytes
+    pub fn new(creator: PublicKey, previous_block_hash: [u8; 32]) -> Self {
         BlockHeader {
             id: 0,
             timestamp: create_timestamp(),
-            parent_hash,
+            previous_block_hash,
             creator,
             burnfee: 0,
             difficulty: 0.0,
@@ -78,10 +78,10 @@ impl Block {
     /// Receives the a publickey and the previous block hash
     ///
     /// * `creator` - `secp256k1::PublicKey` of the block creator
-    /// * `parent_hash` - Previous block hash in bytes
-    pub fn new(creator: PublicKey, parent_hash: [u8; 32]) -> Block {
+    /// * `previous_block_hash` - Previous block hash in bytes
+    pub fn new(creator: PublicKey, previous_block_hash: [u8; 32]) -> Block {
         Block {
-            header: BlockHeader::new(creator, parent_hash),
+            header: BlockHeader::new(creator, previous_block_hash),
             body: BlockBody::new(),
             hash: None,
         }
@@ -97,9 +97,9 @@ impl Block {
         self.header.timestamp
     }
 
-    /// Returns the parent `Block` hash
-    pub fn parent_hash(&self) -> &[u8; 32] {
-        &self.header.parent_hash
+    /// Returns the previous `Block` hash
+    pub fn previous_block_hash(&self) -> &[u8; 32] {
+        &self.header.previous_block_hash
     }
 
     /// Returns the `Block` creator's `secp256k1::PublicKey`
@@ -207,8 +207,12 @@ impl Block {
     }
 
     /// Sets the `Block` previous hash
-    pub fn set_parent_hash(&mut self, parent_hash: [u8; 32]) {
-        update_field(&mut self.hash, &mut self.header.parent_hash, parent_hash)
+    pub fn set_previous_block_hash(&mut self, previous_block_hash: [u8; 32]) {
+        update_field(
+            &mut self.hash,
+            &mut self.header.previous_block_hash,
+            previous_block_hash,
+        )
     }
 
     /// Sets the `Block` difficulty
@@ -253,7 +257,7 @@ mod test {
         let mut block = Block::new(*keypair.public_key(), [0; 32]);
 
         assert_eq!(block.id(), 0);
-        assert_eq!(block.parent_hash(), &[0; 32]);
+        assert_eq!(block.previous_block_hash(), &[0; 32]);
         assert_eq!(block.creator(), keypair.public_key());
         assert_eq!(*block.transactions(), vec![]);
         assert_eq!(block.burnfee(), 0);

--- a/src/block.rs
+++ b/src/block.rs
@@ -8,25 +8,25 @@ use crate::transaction::Transaction;
 /// and additional metadata not to be serialized
 #[derive(PartialEq, Debug, Clone)]
 pub struct Block {
+    /// The header of the block object
+    header: BlockHeader,
     /// The body and content of the block object
     body: BlockBody,
-    /// Byte array hash of the block
-    bsh: [u8; 32],
+    /// Mmemoized hash of the block
+    hash: Option<[u8; 32]>,
 }
-/// This `BlockBody` holds data to be serialized along with
-/// `Transaction`s
+
+/// This `Header` holds `Block`'s metadata
 #[derive(PartialEq, Debug, Clone)]
-pub struct BlockBody {
+pub struct BlockHeader {
     /// Block id
     id: u64,
     /// Block timestamp
     timestamp: u64,
     /// Byte array hash of the previous block in the chain
-    previous_block_hash: [u8; 32],
+    parent_hash: [u8; 32],
     /// `Publickey` of the block creator
     creator: PublicKey,
-    /// List of transactions in the block
-    txs: Vec<Transaction>,
     /// `BurnFee` containing the fees paid to produce the block
     burnfee: u64,
     /// Block difficulty required to win the `LotteryGame` in golden ticket generation
@@ -37,103 +37,112 @@ pub struct BlockBody {
     coinbase: u64,
 }
 
+/// This `BlockBody` holds data to be serialized along with
+/// `Transaction`s
+#[derive(PartialEq, Debug, Clone)]
+pub struct BlockBody {
+    /// List of transactions in the block
+    transactions: Vec<Transaction>,
+}
+
+impl BlockHeader {
+    /// Creates a new `BlockHeader`
+    ///
+    /// * `creator` - `secp256k1::PublicKey` of the block creator
+    /// * `parent_hash` - Parent block hash in bytes
+    pub fn new(creator: PublicKey, parent_hash: [u8; 32]) -> Self {
+        BlockHeader {
+            id: 0,
+            timestamp: create_timestamp(),
+            parent_hash,
+            creator,
+            burnfee: 0,
+            difficulty: 0.0,
+            treasury: 286_810_000_000_000_000,
+            coinbase: 0,
+        }
+    }
+}
+
 impl BlockBody {
     /// Creates a new `BlockBody`
     ///
     /// * `creator` - `secp256k1::PublicKey` of the block creator
     /// * `previous_block_hash` - Previous block hash in bytes
-    pub fn new(creator: PublicKey, previous_block_hash: [u8; 32]) -> BlockBody {
-        return BlockBody {
-            id: 0,
-            timestamp: create_timestamp(),
-            previous_block_hash,
-            creator,
-            txs: vec![],
-            burnfee: 0,
-            difficulty: 0.0,
-            treasury: 286_810_000_000_000_000,
-            coinbase: 0,
-        };
+    pub fn new() -> Self {
+        BlockBody {
+            transactions: vec![],
+        }
     }
 }
 
 impl Block {
     /// Receives the a publickey and the previous block hash
     ///
-    /// * `block_creator` - `secp256k1::PublicKey` of the block creator
-    /// * `previous_block_hash` - Previous block hash in bytes
-    pub fn new(creator: PublicKey, previous_block_hash: [u8; 32]) -> Block {
-        return Block {
-            body: BlockBody::new(creator, previous_block_hash),
-            bsh: [0; 32],
-        };
-    }
-
-    /// Creates a block solely from the block body. Used when
-    /// deserializing a block either from disk or from the network
-    ///
-    /// * `body` - `BlockBody` of new `Block`
-    pub fn from_block_body(body: BlockBody) -> Block {
-        return Block {
-            body: body,
-            bsh: [0; 32],
-        };
+    /// * `creator` - `secp256k1::PublicKey` of the block creator
+    /// * `parent_hash` - Previous block hash in bytes
+    pub fn new(creator: PublicKey, parent_hash: [u8; 32]) -> Block {
+        Block {
+            header: BlockHeader::new(creator, parent_hash),
+            body: BlockBody::new(),
+            hash: None,
+        }
     }
 
     /// Returns the `Block` id
     pub fn id(&self) -> u64 {
-        self.body.id
+        self.header.id
     }
 
     /// Returns the `Block` timestamp
     pub fn timestamp(&self) -> u64 {
-        self.body.timestamp
+        self.header.timestamp
     }
 
-    /// Returns the previous `Block` hash
-    pub fn previous_block_hash(&self) -> &[u8; 32] {
-        &self.body.previous_block_hash
+    /// Returns the parent `Block` hash
+    pub fn parent_hash(&self) -> &[u8; 32] {
+        &self.header.parent_hash
     }
 
     /// Returns the `Block` creator's `secp256k1::PublicKey`
     pub fn creator(&self) -> &PublicKey {
-        &self.body.creator
+        &self.header.creator
     }
 
     /// Returns the `Block`'s `Transaction`s
-    pub fn txs(&self) -> &Vec<Transaction> {
-        &self.body.txs
+    pub fn transactions(&self) -> &Vec<Transaction> {
+        &self.body.transactions
     }
 
     /// Returns the `Block` burnfee
     pub fn burnfee(&self) -> u64 {
-        self.body.burnfee
+        self.header.burnfee
     }
 
     /// Returns the `Block` difficulty
     pub fn difficulty(&self) -> f32 {
-        self.body.difficulty
+        self.header.difficulty
     }
 
     /// Returns the `Block` treasury
     pub fn treasury(&self) -> u64 {
-        self.body.treasury
+        self.header.treasury
     }
 
     /// Returns the `Block` coinbase
     pub fn coinbase(&self) -> u64 {
-        self.body.coinbase
+        self.header.coinbase
     }
 
     /// Generate the block hash
     ///
     /// TODO -- extend list of information we use to calculate the block hash
-    pub fn block_hash(&self) -> [u8; 32] {
+    pub fn hash(&self) -> [u8; 32] {
         let mut data: Vec<u8> = vec![];
 
-        let id_bytes: [u8; 8] = unsafe { transmute(self.body.id.to_be()) };
-        let ts_bytes: [u8; 8] = unsafe { transmute(self.body.timestamp.to_be()) };
-        let cr_bytes: Vec<u8> = self.body.creator.serialize().iter().cloned().collect();
+        let id_bytes: [u8; 8] = unsafe { transmute(self.header.id.to_be()) };
+        let ts_bytes: [u8; 8] = unsafe { transmute(self.header.timestamp.to_be()) };
+        let cr_bytes: Vec<u8> = self.header.creator.serialize().iter().cloned().collect();
 
         data.extend(&id_bytes);
         data.extend(&ts_bytes);
@@ -143,14 +152,14 @@ impl Block {
     }
 
     /// Converts our blockhash from a byte array into a hex string
-    pub fn block_hash_hex(&self) -> String {
-        hex::encode(&self.block_hash())
+    pub fn hash_as_hex(&self) -> String {
+        hex::encode(&self.hash())
     }
 
     /// Sets the `Block`s list of `Transaction`s
     pub fn set_transactions(&mut self, transactions: &mut Vec<Transaction>) {
-        let bid = self.body.id;
-        let bsh = self.block_hash();
+        let bid = self.header.id;
+        let bsh = self.hash();
 
         for (i, tx) in transactions.iter_mut().enumerate() {
             // The slips are assigned the ids based on their slip index
@@ -173,42 +182,53 @@ impl Block {
                 current_sid += 1;
             }
         }
-        self.body.txs = transactions.to_vec();
+        self.body.transactions = transactions.to_vec();
     }
 
     /// Appends a transaction to the block
     pub fn add_transaction(&mut self, tx: Transaction) {
-        self.body.txs.push(tx);
+        self.body.transactions.push(tx);
     }
 
     /// Sets the id of the block
     pub fn set_id(&mut self, id: u64) {
-        self.body.id = id;
+        self.header.id = id;
     }
 
     /// Sets the `Block` burnfee
     pub fn set_burnfee(&mut self, bf: u64) {
-        self.body.burnfee = bf;
+        self.header.burnfee = bf;
     }
 
     /// Sets the `Block` previous hash
-    pub fn set_previous_block_hash(&mut self, prevbsh: [u8; 32]) {
-        self.body.previous_block_hash = prevbsh;
+    pub fn set_parent_hash(&mut self, parent_hash: [u8; 32]) {
+        self.header.parent_hash = parent_hash;
     }
 
     /// Sets the `Block` difficulty
     pub fn set_difficulty(&mut self, difficulty: f32) {
-        self.body.difficulty = difficulty;
+        self.header.difficulty = difficulty;
     }
 
     /// Sets the `Block` treasury
     pub fn set_treasury(&mut self, treasury: u64) {
-        self.body.treasury = treasury;
+        self.header.treasury = treasury;
     }
 
     /// Sets the `Block` coinbase
     pub fn set_coinbase(&mut self, coinbase: u64) {
-        self.body.coinbase = coinbase;
+        self.header.coinbase = coinbase;
+    }
+}
+
+/// Update value of given field, reset memoised hash if changed.
+fn update_field<T>(hash: &mut Option<[u8; 32]>, field: &mut T, value: T)
+where
+    T: PartialEq<T>,
+{
+    if field != &value {
+        *field = value;
+        *hash = None;
     }
 }
 
@@ -227,9 +247,9 @@ mod test {
         let mut block = Block::new(*keypair.public_key(), [0; 32]);
 
         assert_eq!(block.id(), 0);
-        assert_eq!(block.previous_block_hash(), &[0; 32]);
+        assert_eq!(block.parent_hash(), &[0; 32]);
         assert_eq!(block.creator(), keypair.public_key());
-        assert_eq!(*block.txs(), vec![]);
+        assert_eq!(*block.transactions(), vec![]);
         assert_eq!(block.burnfee(), 0);
         assert_eq!(block.difficulty(), 0.0);
         assert_eq!(block.treasury(), 286_810_000_000_000_000);
@@ -263,15 +283,15 @@ mod test {
         tx.add_output(to_slip);
         block.set_transactions(&mut vec![tx.clone()]);
 
-        assert_eq!(block.txs().len(), 1);
+        assert_eq!(block.transactions().len(), 1);
 
-        assert_eq!(block.txs()[0].outputs()[0].slip_id(), 0);
-        assert_eq!(block.txs()[0].outputs()[0].tx_id(), 0);
-        assert_eq!(block.txs()[0].outputs()[0].block_id(), 0);
+        assert_eq!(block.transactions()[0].outputs()[0].slip_id(), 0);
+        assert_eq!(block.transactions()[0].outputs()[0].tx_id(), 0);
+        assert_eq!(block.transactions()[0].outputs()[0].block_id(), 0);
 
-        assert_eq!(block.txs()[0].inputs()[0].slip_id(), 1);
-        assert_eq!(block.txs()[0].inputs()[0].tx_id(), 0);
-        assert_eq!(block.txs()[0].inputs()[0].block_id(), 0);
+        assert_eq!(block.transactions()[0].inputs()[0].slip_id(), 1);
+        assert_eq!(block.transactions()[0].inputs()[0].tx_id(), 0);
+        assert_eq!(block.transactions()[0].inputs()[0].block_id(), 0);
     }
 
     #[test]
@@ -279,8 +299,8 @@ mod test {
         let keypair = Keypair::new();
         let mut block = Block::new(*keypair.public_key(), [0; 32]);
         let tx = Transaction::new(TransactionBroadcastType::Normal);
-        assert_eq!(*block.txs(), vec![]);
+        assert_eq!(*block.transactions(), vec![]);
         block.add_transaction(tx.clone());
-        assert_eq!(*block.txs(), vec![tx.clone()]);
+        assert_eq!(*block.transactions(), vec![tx.clone()]);
     }
 }

--- a/src/block.rs
+++ b/src/block.rs
@@ -159,7 +159,6 @@ impl Block {
     /// Sets the `Block`s list of `Transaction`s
     pub fn set_transactions(&mut self, transactions: &mut Vec<Transaction>) {
         let bid = self.header.id;
-        let bsh = self.hash();
 
         for (i, tx) in transactions.iter_mut().enumerate() {
             // The slips are assigned the ids based on their slip index
@@ -178,7 +177,6 @@ impl Block {
                 slip.set_block_id(bid);
                 slip.set_tx_id(i as u64);
                 slip.set_slip_id(current_sid);
-                slip.set_block_hash(bsh);
                 current_sid += 1;
             }
         }

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -87,7 +87,7 @@ impl Mempool {
                 block.set_id(previous_block.id() + 1);
                 block.set_coinbase(coinbase);
                 block.set_treasury(treasury - coinbase);
-                block.set_parent_hash(previous_block.hash());
+                block.set_previous_block_hash(previous_block.hash());
                 block.set_difficulty(previous_block.difficulty());
 
                 self._burnfee
@@ -134,7 +134,7 @@ mod tests {
         match new_block {
             Some(block) => {
                 assert_eq!(block.id(), 0);
-                assert_eq!(*block.parent_hash(), [0; 32]);
+                assert_eq!(*block.previous_block_hash(), [0; 32]);
             }
             None => {}
         }

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -78,7 +78,7 @@ impl Mempool {
 
         match previous_block {
             Some(previous_block) => {
-                block = Block::new(publickey.clone(), previous_block.block_hash());
+                block = Block::new(publickey.clone(), previous_block.hash());
 
                 // TODO -- include reclaimed fees here
                 let treasury = previous_block.treasury();
@@ -87,7 +87,7 @@ impl Mempool {
                 block.set_id(previous_block.id() + 1);
                 block.set_coinbase(coinbase);
                 block.set_treasury(treasury - coinbase);
-                block.set_previous_block_hash(previous_block.block_hash());
+                block.set_parent_hash(previous_block.hash());
                 block.set_difficulty(previous_block.difficulty());
 
                 self._burnfee
@@ -134,7 +134,7 @@ mod tests {
         match new_block {
             Some(block) => {
                 assert_eq!(block.id(), 0);
-                assert_eq!(*block.previous_block_hash(), [0; 32]);
+                assert_eq!(*block.parent_hash(), [0; 32]);
             }
             None => {}
         }

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -11,8 +11,6 @@ pub struct Slip {
     tx_id: u64,
     /// `Slip` id
     slip_id: u64,
-    /// The `Block` hash the slip originated from
-    block_hash: [u8; 32],
 }
 
 /// An object that holds concrete data not subjective to state of chain
@@ -38,8 +36,8 @@ impl Slip {
     /// * `address` - `Publickey` address to assign ownership
     /// * `broadcast_type` - `SlipBroadcastType` of `Slip`
     /// * `amount` - `u64` amount of Saito contained in the `Slip`
-    pub fn new(address: PublicKey, broadcast_type: SlipBroadcastType, amount: u64) -> Slip {
-        return Slip {
+    pub fn new(address: PublicKey, broadcast_type: SlipBroadcastType, amount: u64) -> Self {
+        Slip {
             body: SlipBody {
                 address,
                 broadcast_type,
@@ -48,8 +46,7 @@ impl Slip {
             block_id: 0,
             tx_id: 0,
             slip_id: 0,
-            block_hash: [0; 32],
-        };
+        }
     }
 
     /// Returns address in `Slip`
@@ -82,11 +79,6 @@ impl Slip {
         self.slip_id
     }
 
-    /// Returns the `Block` hash the slip originated from
-    pub fn block_hash(&self) -> [u8; 32] {
-        self.block_hash
-    }
-
     // Set the `Block` id
     pub fn set_block_id(&mut self, block_id: u64) {
         self.block_id = block_id;
@@ -101,23 +93,16 @@ impl Slip {
     pub fn set_slip_id(&mut self, slip_id: u64) {
         self.slip_id = slip_id;
     }
-
-    // Set the `Block` hash
-    pub fn set_block_hash(&mut self, block_hash: [u8; 32]) {
-        self.block_hash = block_hash;
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::keypair::Keypair;
-    use rand;
 
     #[test]
     fn slip_test() {
         let keypair = Keypair::new();
-        let block_hash: [u8; 32] = rand::random();
         let mut slip = Slip::new(
             keypair.public_key().clone(),
             SlipBroadcastType::Normal,
@@ -130,16 +115,13 @@ mod tests {
         assert_eq!(slip.block_id(), 0);
         assert_eq!(slip.tx_id(), 0);
         assert_eq!(slip.slip_id(), 0);
-        assert_eq!(slip.block_hash(), [0; 32]);
 
         slip.set_block_id(10);
         slip.set_tx_id(10);
         slip.set_slip_id(10);
-        slip.set_block_hash(block_hash);
 
         assert_eq!(slip.block_id(), 10);
         assert_eq!(slip.tx_id(), 10);
         assert_eq!(slip.slip_id(), 10);
-        assert_eq!(slip.block_hash(), block_hash);
     }
 }


### PR DESCRIPTION
- Introduce `BlockHeader` to separate block metadata
- Rename `txs` to `transactions` to be consistent with `mempool.rs`
- Fix unreliable hash memoization. Instead of removing it completely, I reset the cached hash value upon update of any field.
- Remove unsafe{} calls in `hash()`. I didn't change the hashing function yet..
- Remove block_hash from Slip as it is hard to update it all the time and I believe it is a bad design.