### PR TITLE
return of the shashmap

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,5 +1,5 @@
 use crate::block::{Block, BlockHeader};
-use crate::utxoset::UTXOSet;
+use crate::shashmap::Shashmap;
 
 pub type BlockIndex = (BlockHeader, [u8; 32]);
 /// Indexes of chain attribute
@@ -25,7 +25,7 @@ pub struct Blockchain {
     /// Index of `Block`s
     index: BlockchainIndex,
     /// Hashmap of slips used by the network
-    utxoset: UTXOSet,
+    shashmap: Shashmap,
 }
 
 impl Blockchain {
@@ -33,7 +33,7 @@ impl Blockchain {
     pub fn new() -> Self {
         Blockchain {
             index: BlockchainIndex::new(),
-            utxoset: UTXOSet::new(),
+            shashmap: Shashmap::new(),
         }
     }
 
@@ -47,7 +47,7 @@ impl Blockchain {
     /// * `block` - `Block` appended to index
     pub fn add_block(&mut self, block: Block) {
         for tx in block.transactions().iter() {
-            self.utxoset.insert_new_transaction(tx);
+            self.shashmap.insert_new_transaction(tx);
         }
 
         let block_index: BlockIndex = (block.header().clone(), block.hash());
@@ -111,6 +111,6 @@ mod tests {
         let (block_header, _) = blockchain.index.blocks[0].clone();
 
         assert_eq!(block_header, *block.clone().header());
-        assert_eq!(blockchain.utxoset.slip_block_id(&slip), Some(&-1));
+        assert_eq!(blockchain.shashmap.slip_block_id(&slip), Some(&-1));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod slip;
 pub mod time;
 pub mod transaction;
 pub mod types;
-pub mod utxoset;
+pub mod shashmap;
 
 /// Error returned by most functions.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ pub mod crypto;
 pub mod golden_ticket;
 pub mod keypair;
 pub mod mempool;
+pub mod shashmap;
 pub mod slip;
 pub mod time;
 pub mod transaction;
 pub mod types;
-pub mod shashmap;
 
 /// Error returned by most functions.
 ///

--- a/src/shashmap.rs
+++ b/src/shashmap.rs
@@ -6,14 +6,14 @@ use std::collections::HashMap;
 /// with the `Block` ids as values. This is used to enforce when
 /// `Slip`s have been spent in the network
 #[derive(Debug, Clone)]
-pub struct UTXOSet {
+pub struct Shashmap {
     utxo_hashmap: HashMap<Slip, i64>,
 }
 
-impl UTXOSet {
-    /// Create new `UTXOSet`
+impl Shashmap {
+    /// Create new `Shashmap`
     pub fn new() -> Self {
-        UTXOSet {
+        Shashmap {
             utxo_hashmap: HashMap::new(),
         }
     }
@@ -93,23 +93,23 @@ mod test {
     use std::collections::HashMap;
 
     #[test]
-    fn utxoset_test() {
-        let utxoset = UTXOSet::new();
-        assert_eq!(utxoset.utxo_hashmap, HashMap::new());
+    fn shashmap_test() {
+        let shashmap = Shashmap::new();
+        assert_eq!(shashmap.utxo_hashmap, HashMap::new());
     }
 
     #[test]
-    fn utxoset_insert_test() {
-        let mut utxoset = UTXOSet::new();
+    fn shashmap_insert_test() {
+        let mut shashmap = Shashmap::new();
         let keypair = Keypair::new();
         let slip = Slip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
-        utxoset.insert(slip, 0);
-        assert!(utxoset.utxo_hashmap.contains_key(&slip));
+        shashmap.insert(slip, 0);
+        assert!(shashmap.utxo_hashmap.contains_key(&slip));
     }
 
     #[test]
-    fn utxoset_insert_new_transaction_test() {
-        let mut utxoset = UTXOSet::new();
+    fn shashmap_insert_new_transaction_test() {
+        let mut shashmap = Shashmap::new();
         let mut tx = Transaction::new(TransactionBroadcastType::Normal);
 
         let keypair = Keypair::new();
@@ -117,15 +117,15 @@ mod test {
 
         tx.add_output(output_slip);
 
-        utxoset.insert_new_transaction(&tx);
+        shashmap.insert_new_transaction(&tx);
 
-        assert!(utxoset.utxo_hashmap.contains_key(&output_slip));
-        assert_eq!(utxoset.utxo_hashmap.get(&output_slip).unwrap(), &-1);
+        assert!(shashmap.utxo_hashmap.contains_key(&output_slip));
+        assert_eq!(shashmap.utxo_hashmap.get(&output_slip).unwrap(), &-1);
     }
 
     #[test]
-    fn utxoset_spend_transaction_test() {
-        let mut utxoset = UTXOSet::new();
+    fn shashmap_spend_transaction_test() {
+        let mut shashmap = Shashmap::new();
         let mut tx = Transaction::new(TransactionBroadcastType::Normal);
 
         let keypair = Keypair::new();
@@ -133,15 +133,15 @@ mod test {
 
         tx.add_input(input_slip);
 
-        utxoset.spend_transaction(&tx, 0);
+        shashmap.spend_transaction(&tx, 0);
 
-        assert!(utxoset.utxo_hashmap.contains_key(&input_slip));
-        assert_eq!(utxoset.utxo_hashmap.get(&input_slip).unwrap(), &0);
+        assert!(shashmap.utxo_hashmap.contains_key(&input_slip));
+        assert_eq!(shashmap.utxo_hashmap.get(&input_slip).unwrap(), &0);
     }
 
     #[test]
-    fn utxoset_unspend_transaction_test() {
-        let mut utxoset = UTXOSet::new();
+    fn shashmap_unspend_transaction_test() {
+        let mut shashmap = Shashmap::new();
         let mut tx = Transaction::new(TransactionBroadcastType::Normal);
 
         let keypair = Keypair::new();
@@ -149,47 +149,47 @@ mod test {
 
         tx.add_input(input_slip);
 
-        utxoset.unspend_transaction(&tx);
+        shashmap.unspend_transaction(&tx);
 
-        assert!(utxoset.utxo_hashmap.contains_key(&input_slip));
-        assert_eq!(utxoset.utxo_hashmap.get(&input_slip).unwrap(), &-1);
+        assert!(shashmap.utxo_hashmap.contains_key(&input_slip));
+        assert_eq!(shashmap.utxo_hashmap.get(&input_slip).unwrap(), &-1);
     }
 
     #[test]
-    fn utxoset_spend_slip_test() {
-        let mut utxoset = UTXOSet::new();
+    fn shashmap_spend_slip_test() {
+        let mut shashmap = Shashmap::new();
 
         let keypair = Keypair::new();
         let input_slip = Slip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
 
-        utxoset.spend_slip(&input_slip, 0);
+        shashmap.spend_slip(&input_slip, 0);
 
-        assert!(utxoset.utxo_hashmap.contains_key(&input_slip));
-        assert_eq!(utxoset.utxo_hashmap.get(&input_slip).unwrap(), &0);
+        assert!(shashmap.utxo_hashmap.contains_key(&input_slip));
+        assert_eq!(shashmap.utxo_hashmap.get(&input_slip).unwrap(), &0);
     }
 
     #[test]
-    fn utxoset_unspend_slip_test() {
-        let mut utxoset = UTXOSet::new();
+    fn shashmap_unspend_slip_test() {
+        let mut shashmap = Shashmap::new();
 
         let keypair = Keypair::new();
         let input_slip = Slip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
 
-        utxoset.unspend_slip(&input_slip);
+        shashmap.unspend_slip(&input_slip);
 
-        assert!(utxoset.utxo_hashmap.contains_key(&input_slip));
-        assert_eq!(utxoset.utxo_hashmap.get(&input_slip).unwrap(), &-1);
+        assert!(shashmap.utxo_hashmap.contains_key(&input_slip));
+        assert_eq!(shashmap.utxo_hashmap.get(&input_slip).unwrap(), &-1);
     }
 
     #[test]
-    fn utxoset_slip_block_id_test() {
-        let mut utxoset = UTXOSet::new();
+    fn shashmap_slip_block_id_test() {
+        let mut shashmap = Shashmap::new();
 
         let keypair = Keypair::new();
         let slip = Slip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
-        utxoset.insert(slip, 1);
+        shashmap.insert(slip, 1);
 
-        match utxoset.slip_block_id(&slip) {
+        match shashmap.slip_block_id(&slip) {
             Some(id) => assert_eq!(id, &1),
             _ => assert!(false),
         }


### PR DESCRIPTION
Minor change -- shashmap should be a generic key=>value data structure as opposed to a class to one use-case. We can instantiate it in ways that make it clear what the shashmap is being used to manage:

let utxoset = Shashmap::new();

The storage class Stephen is putting together will basically need to support saving blocks to disk and managing the UTXO set in this routing client (i.e. no need to database support) so it shouldn't be a problem to use it as the API contact point for updates to the UTXO set.

Need another reason? Hannes suggested I update my user.email and I'm admittedly curious if it makes a different in how this appears. So welcome back, Shashmap. It has been too long!