### PR TITLE
clean up slip

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -60,7 +60,7 @@ mod tests {
     use super::*;
     use crate::block::Block;
     use crate::keypair::Keypair;
-    use crate::slip::{Slip, SlipBroadcastType};
+    use crate::slip::{OutputSlip, SlipBroadcastType};
     use crate::transaction::{Transaction, TransactionType};
     use secp256k1::Signature;
 
@@ -98,12 +98,8 @@ mod tests {
         let mut blockchain = Blockchain::new();
         let mut block = Block::new(keypair.public_key().clone(), [0; 32]);
         let mut transaction = Transaction::new(TransactionType::Normal);
-        let slip = Slip::new(
-            *keypair.public_key(),
-            SlipBroadcastType::Normal,
-            2_0000_0000,
-        );
-        transaction.add_output(slip);
+        let to_slip = OutputSlip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
+        transaction.add_output(to_slip);
 
         let signed_transaction =
             Transaction::add_signature(transaction, Signature::from_compact(&[0; 64]).unwrap());

--- a/src/golden_ticket.rs
+++ b/src/golden_ticket.rs
@@ -2,7 +2,7 @@ use crate::{
     block::Block,
     crypto::PublicKey,
     keypair::Keypair,
-    slip::{Slip, SlipBroadcastType},
+    slip::{OutputSlip, SlipBroadcastType},
     transaction::{Transaction, TransactionType},
 };
 use secp256k1::Signature;
@@ -58,8 +58,8 @@ pub fn generate_golden_ticket_transaction(
 
     let mut golden_tx_body = Transaction::new(TransactionType::Normal);
 
-    let miner_slip = Slip::new(*publickey, SlipBroadcastType::Normal, miner_share);
-    let node_slip = Slip::new(winning_address, SlipBroadcastType::Normal, node_share);
+    let miner_slip = OutputSlip::new(*publickey, SlipBroadcastType::Normal, miner_share);
+    let node_slip = OutputSlip::new(winning_address, SlipBroadcastType::Normal, node_share);
 
     golden_tx_body.add_output(miner_slip);
     golden_tx_body.add_output(node_slip);

--- a/src/shashmap.rs
+++ b/src/shashmap.rs
@@ -1,13 +1,12 @@
-use crate::slip::Slip;
+use crate::slip::{OutputSlip, SlipID};
 use crate::transaction::Transaction;
 use std::collections::HashMap;
 
-/// A hashmap storing the byte arrays of `Slip`s as keys
-/// with the `Block` ids as values. This is used to enforce when
-/// `Slip`s have been spent in the network
+/// A hashmap storing Slips TODO fix this documentation once we've settled on what
+/// data structures actually belong here.
 #[derive(Debug, Clone)]
 pub struct Shashmap {
-    utxo_hashmap: HashMap<Slip, i64>,
+    utxo_hashmap: HashMap<SlipID, OutputSlip>,
 }
 
 impl Shashmap {
@@ -29,10 +28,10 @@ impl Shashmap {
     /// * `tx` - `Transaction` where inputs are inserted, and outputs are removed
     pub fn unspend_transaction(&mut self, _tx: &Transaction) {}
 
-    /// Return the `Block` id based on `Slip`
+    /// Return the `Block` id based on `OutputSlip`
     ///
-    /// * `slip` - `&Slip` as key
-    pub fn slip_block_id(&self, slip: &Slip) -> Option<&i64> {
+    /// * `slip` - `&OutputSlip` as key
+    pub fn slip_block_id(&self, slip: &SlipID) -> Option<&OutputSlip> {
         self.utxo_hashmap.get(slip)
     }
 }

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -1,11 +1,15 @@
 use secp256k1::PublicKey;
 use std::hash::Hash;
 
+/// An enumerated set of `Slip` types
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub enum SlipBroadcastType {
+    Normal,
+}
+
 /// A record of owernship of funds on the network
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
-pub struct Slip {
-    /// Contains concrete data which is not relative to state of the chain
-    body: SlipBody,
+pub struct SlipID {
     /// `Block` id
     block_id: u64,
     /// `Transaction` id
@@ -16,7 +20,7 @@ pub struct Slip {
 
 /// An object that holds concrete data not subjective to state of chain
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
-pub struct SlipBody {
+pub struct OutputSlip {
     /// An `Sectp256K::PublicKey` determining who owns the `Slip`
     address: PublicKey,
     /// A enum brodcast type determining how to be processed by consensus
@@ -25,46 +29,15 @@ pub struct SlipBody {
     amount: u64,
 }
 
-/// An enumerated set of `Slip` types
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
-pub enum SlipBroadcastType {
-    Normal,
-}
-
-impl Slip {
-    /// Create new `Slip` with default type `SlipBroadcastType::Normal`
-    ///
-    /// * `address` - `Publickey` address to assign ownership
-    /// * `broadcast_type` - `SlipBroadcastType` of `Slip`
-    /// * `amount` - `u64` amount of Saito contained in the `Slip`
-    pub fn new(address: PublicKey, broadcast_type: SlipBroadcastType, amount: u64) -> Self {
-        Slip {
-            body: SlipBody {
-                address,
-                broadcast_type,
-                amount,
-            },
-            block_id: 0,
-            tx_id: 0,
-            slip_id: 0,
+impl SlipID {
+    /// Create new `SlipID`
+    pub fn new(block_id: u64, tx_id: u64, slip_id: u64) -> SlipID {
+        SlipID {
+            block_id: block_id,
+            tx_id: tx_id,
+            slip_id: slip_id,
         }
     }
-
-    /// Returns address in `Slip`
-    pub fn address(&self) -> &PublicKey {
-        &self.body.address
-    }
-
-    /// Returns`Slip` type from the enumerated set of `SlipBroadcastType`
-    pub fn broadcast_type(&self) -> SlipBroadcastType {
-        self.body.broadcast_type
-    }
-
-    /// Returns amount of Saito in `Slip`
-    pub fn amount(&self) -> u64 {
-        self.body.amount
-    }
-
     /// Returns the `Block` id the slip originated from
     pub fn block_id(&self) -> u64 {
         self.block_id
@@ -79,20 +52,30 @@ impl Slip {
     pub fn slip_id(&self) -> u64 {
         self.slip_id
     }
+}
 
-    /// Set the `Block` id
-    pub fn set_block_id(&mut self, block_id: u64) {
-        self.block_id = block_id;
+impl OutputSlip {
+    /// Create new `OutputSlip`
+    pub fn new(address: PublicKey, broadcast_type: SlipBroadcastType, amount: u64) -> OutputSlip {
+        OutputSlip {
+            address: address,
+            broadcast_type: broadcast_type,
+            amount: amount,
+        }
+    }
+    /// Returns address in `Slip`
+    pub fn address(&self) -> &PublicKey {
+        &self.address
     }
 
-    /// Set the `Transaction` id
-    pub fn set_tx_id(&mut self, tx_id: u64) {
-        self.tx_id = tx_id;
+    /// Returns`Slip` type from the enumerated set of `SlipBroadcastType`
+    pub fn broadcast_type(&self) -> SlipBroadcastType {
+        self.broadcast_type
     }
 
-    /// Set the `Slip` id
-    pub fn set_slip_id(&mut self, slip_id: u64) {
-        self.slip_id = slip_id;
+    /// Returns amount of Saito in `Slip`
+    pub fn amount(&self) -> u64 {
+        self.amount
     }
 }
 
@@ -104,7 +87,7 @@ mod tests {
     #[test]
     fn slip_test() {
         let keypair = Keypair::new();
-        let mut slip = Slip::new(
+        let slip = OutputSlip::new(
             keypair.public_key().clone(),
             SlipBroadcastType::Normal,
             10_000_000,
@@ -113,16 +96,5 @@ mod tests {
         assert_eq!(slip.address(), keypair.public_key());
         assert_eq!(slip.broadcast_type(), SlipBroadcastType::Normal);
         assert_eq!(slip.amount(), 10_000_000);
-        assert_eq!(slip.block_id(), 0);
-        assert_eq!(slip.tx_id(), 0);
-        assert_eq!(slip.slip_id(), 0);
-
-        slip.set_block_id(10);
-        slip.set_tx_id(10);
-        slip.set_slip_id(10);
-
-        assert_eq!(slip.block_id(), 10);
-        assert_eq!(slip.tx_id(), 10);
-        assert_eq!(slip.slip_id(), 10);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,4 +1,7 @@
-use crate::{slip::Slip, time::create_timestamp};
+use crate::{
+    slip::{OutputSlip, SlipID},
+    time::create_timestamp,
+};
 use secp256k1::{PublicKey, Signature};
 
 /// A single record used in the history of transactions being routed around the network
@@ -54,10 +57,10 @@ pub struct Transaction {
 pub struct TransactionBody {
     /// UNIX timestamp when the `Transaction` was created
     timestamp: u64,
-    /// A list of `Slip` inputs
-    inputs: Vec<Slip>,
-    /// A list of `Slip` outputs
-    outputs: Vec<Slip>,
+    /// A list of `SlipID` inputs
+    inputs: Vec<SlipID>,
+    /// A list of `OutputSlip` outputs
+    outputs: Vec<OutputSlip>,
     /// A enum brodcast type determining how to process `Transaction` in consensus
     broadcast_type: TransactionType,
     /// A byte array of miscellaneous information
@@ -110,33 +113,33 @@ impl TransactionBody {
         self.timestamp
     }
 
-    /// Returns list of `Slip` outputs
-    pub fn outputs(&self) -> &Vec<Slip> {
+    /// Returns list of `OutputSlip` outputs
+    pub fn outputs(&self) -> &Vec<OutputSlip> {
         &self.outputs
     }
 
-    /// Returns list of mutable `Slip` outputs
-    pub fn outputs_mut(&mut self) -> &mut Vec<Slip> {
+    /// Returns list of mutable `OutputSlip` outputs
+    pub fn outputs_mut(&mut self) -> &mut Vec<OutputSlip> {
         &mut self.outputs
     }
 
-    /// Add a new `Slip` to the list of `Slip` outputs
-    pub fn add_output(&mut self, slip: Slip) {
+    /// Add a new `OutputSlip` to the list of `Slip` outputs
+    pub fn add_output(&mut self, slip: OutputSlip) {
         self.outputs.push(slip);
     }
 
-    /// Returns list of `Slip` inputs
-    pub fn inputs(&self) -> &Vec<Slip> {
+    /// Returns list of `SlipID` inputs
+    pub fn inputs(&self) -> &Vec<SlipID> {
         &self.inputs
     }
 
-    /// Returns list of `Slip` inputs
-    pub fn inputs_mut(&mut self) -> &mut Vec<Slip> {
+    /// Returns list of `SlipID` inputs
+    pub fn inputs_mut(&mut self) -> &mut Vec<SlipID> {
         &mut self.inputs
     }
 
-    /// Add a new `Slip` to the list of `Slip` inputs
-    pub fn add_input(&mut self, slip: Slip) {
+    /// Add a new `SlipID` to the list of `SlipID` inputs
+    pub fn add_input(&mut self, slip: SlipID) {
         self.inputs.push(slip);
     }
 
@@ -156,7 +159,7 @@ mod tests {
     use super::*;
     use crate::{
         keypair::Keypair,
-        slip::{Slip, SlipBroadcastType},
+        slip::{OutputSlip, SlipBroadcastType, SlipID},
     };
 
     #[test]
@@ -171,8 +174,8 @@ mod tests {
         assert_eq!(tx.message(), &vec![]);
 
         let keypair = Keypair::new();
-        let to_slip = Slip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
-        let from_slip = Slip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
+        let to_slip = OutputSlip::new(keypair.public_key().clone(), SlipBroadcastType::Normal, 0);
+        let from_slip = SlipID::new(10, 10, 10);
 
         // let hop_message_bytes = Keypair::make_message_from_string("message_string");
         // let signature = keypair.sign_message(&hop_message_bytes);


### PR DESCRIPTION
The purpose of this is to fix shashmap in two PRs. I'm not sure what the proper data structures of shashmap, but we will have trouble discussing it I think until we get the Slip types right.

An output only needs an address and amount(and maybe a type). An input, is a reference to an output, which I'm refering to as "SlipID" these days. In saito-lite, we use (block_id, tx_id, slip_id) as SlipID. I don't think this is correct, but I want ot save that disucsion for another PR. The important thing to me is that we get these types right, i.e. Output = (address, amount, type) and Input = a reference/id. Then, I think the shashmap maybe only need to contain the Inputs/SlipIDs....

The current implementation mixes all this into a single type and thereby necessates zeroing/nulling out values at times, doesn't enforce type-safety when only one of the above types is really needed, makes serialization extra confusing, and potentially make the shashmap extra diffcult to maintain correctly and unnecessarily large.