### PR TITLE
Block id for mock blocks

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -28,14 +28,18 @@ impl Block {
         Block::new(0, 0.0, BlockCore::default())
     }
     /// Creates a new `BlockCore`
-    pub fn new_mock(previous_block_hash: Sha256Hash, transactions: Vec<Transaction>) -> Self {
+    pub fn new_mock(
+        previous_block_hash: Sha256Hash,
+        transactions: Vec<Transaction>,
+        block_id: u64,
+    ) -> Self {
         let public_key: PublicKey = PublicKey::from_str(
             "0225ee90fc71570613b42e29912a760bb0b2da9182b2a4271af9541b7c5e278072",
         )
         .unwrap();
         let timestamp = create_timestamp();
         let block_core = BlockCore::new(
-            0,
+            block_id,
             timestamp,
             previous_block_hash,
             public_key,
@@ -253,7 +257,7 @@ mod test {
             "0225ee90fc71570613b42e29912a760bb0b2da9182b2a4271af9541b7c5e278072",
         )
         .unwrap();
-        let block = test_utilities::make_mock_block([0; 32]);
+        let block = test_utilities::make_mock_block([0; 32], 0);
         assert_eq!(block.transactions().len(), 1);
         assert_eq!(
             block.transactions()[0].core.outputs()[0].address(),

--- a/src/block.rs
+++ b/src/block.rs
@@ -230,7 +230,6 @@ mod test {
     use crate::block::Block;
     use crate::slip::SlipType;
     use crate::test_utilities;
-    use secp256k1::Signature;
 
     #[test]
     fn block_test() {

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -6,14 +6,14 @@ use crate::longest_chain_queue::LongestChainQueue;
 use crate::transaction::Transaction;
 use crate::utxoset::UtxoSet;
 
-lazy_static! {
-    // This allows us to get a reference to blockchain, utxoset, longest_chain_queue, or fork_tree
-    // from anywhere in the codebase. In the future we can also use message passing or put
-    // other objects into global statics when needed. This is just a temporary solution to get
-    // things working before we optimize.
-    // To use: add crate::blockchain::BLOCKCHAIN and add getters to Blockchain if needed
-    pub static ref BLOCKCHAIN: Blockchain = Blockchain::new();
-}
+// lazy_static! {
+//     // This allows us to get a reference to blockchain, utxoset, longest_chain_queue, or fork_tree
+//     // from anywhere in the codebase. In the future we can also use message passing or put
+//     // other objects into global statics when needed. This is just a temporary solution to get
+//     // things working before we optimize.
+//     // To use: add crate::blockchain::BLOCKCHAIN and add getters to Blockchain if needed
+//     pub static ref BLOCKCHAIN: Blockchain = Blockchain::new().clone();
+// }
 
 /// Enumerated types of `Transaction`s to be handlded by consensus
 #[derive(Debug, PartialEq, Clone)]
@@ -70,8 +70,11 @@ impl Blockchain {
     }
 
     // Get the block from fork_tree and check if the hash matches the one in longest_chain_queue
-    fn _contains_block_hash_in_longest_chain(&self, block_hash: &Sha256Hash) -> bool {
-        self.longest_chain_queue.contains_hash(block_hash)
+    fn _contains_block_hash_in_longest_chain(&self, block_hash: Sha256Hash, block_id: u64) -> bool {
+        self.longest_chain_queue.contains_hash(&block_hash)
+            && self
+                .longest_chain_queue
+                .contains_hash_by_block_id(block_hash, block_id)
     }
 
     /// If the block is in the fork
@@ -206,6 +209,16 @@ impl Blockchain {
         if !self.fork_tree.contains_block_hash(previous_block_hash) {
             return false;
         }
+        if self
+            .fork_tree
+            .block_by_hash(previous_block_hash)
+            .unwrap()
+            .id()
+            + 1
+            != block.id()
+        {
+            return false;
+        }
 
         // TODO -- include checks on difficulty and paysplit here to validate
 
@@ -294,75 +307,69 @@ impl Blockchain {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
-    // use crate::block::Block;
-    // use crate::keypair::Keypair;
-    // use crate::slip::{OutputSlip, SlipID};
-    // use crate::transaction::{Transaction, TransactionType};
-    // use secp256k1::Signature;
-
     use crate::test_utilities;
-    // #[test]
-    // fn validation_test() {
-    //     let blockchain = Blockchain::new();
-    //     let block = test_utilities::make_mock_block([0; 32]);
-    //     assert!(blockchain.validate_block(&block));
-    // }
+
     #[test]
     fn add_block_test() {
         let mut blockchain = Blockchain::new();
-        let block = test_utilities::make_mock_block([0; 32]);
+        let block = test_utilities::make_mock_block([0; 32], 0);
         let mut prev_block_hash = block.hash().clone();
+        let mut prev_block_id = block.id();
         let first_block_hash = block.hash().clone();
         let result: AddBlockEvent = blockchain.add_block(block.clone());
         //println!("{:?}", result);
         assert_eq!(result, AddBlockEvent::AcceptedAsLongestChain);
         for _n in 0..5 {
-            let block = test_utilities::make_mock_block(prev_block_hash);
+            let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
             prev_block_hash = block.hash().clone();
+            prev_block_id = block.id();
             let result: AddBlockEvent = blockchain.add_block(block.clone());
             //println!("{:?}", result);
             assert_eq!(result, AddBlockEvent::AcceptedAsLongestChain);
         }
         // make a fork
-        let block = test_utilities::make_mock_block(first_block_hash);
-        let mut prev_block_hash = block.hash().clone();
+        let block = test_utilities::make_mock_block(first_block_hash, 1);
         let result: AddBlockEvent = blockchain.add_block(block.clone());
+        prev_block_hash = block.hash().clone();
+        prev_block_id = block.id();
         //println!("{:?}", result);
         assert_eq!(result, AddBlockEvent::Accepted);
 
         for _n in 0..4 {
-            let block = test_utilities::make_mock_block(prev_block_hash);
+            let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
             prev_block_hash = block.hash().clone();
+            prev_block_id = block.id();
             let result: AddBlockEvent = blockchain.add_block(block.clone());
             //println!("{:?}", result);
             assert_eq!(result, AddBlockEvent::Accepted);
         }
         // new longest chain tip on top of the fork
-        let block = test_utilities::make_mock_block(prev_block_hash);
+        let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
         let result: AddBlockEvent = blockchain.add_block(block.clone());
         //println!("{:?}", result);
         assert_eq!(result, AddBlockEvent::AcceptedAsNewLongestChain);
 
         // make another fork
-        let block = test_utilities::make_mock_block(first_block_hash);
-        let mut prev_block_hash = block.hash().clone();
+        let block = test_utilities::make_mock_block(first_block_hash, 1);
         let result: AddBlockEvent = blockchain.add_block(block.clone());
+        prev_block_hash = block.hash().clone();
+        prev_block_id = block.id();
         //println!("{:?}", result);
         assert_eq!(result, AddBlockEvent::Accepted);
 
         for _n in 0..5 {
-            let block = test_utilities::make_mock_block(prev_block_hash);
+            let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
             prev_block_hash = block.hash().clone();
+            prev_block_id = block.id();
             let result: AddBlockEvent = blockchain.add_block(block.clone());
             //println!("{:?}", result);
             assert_eq!(result, AddBlockEvent::Accepted);
         }
         // new longest chain tip on top of the fork
-        let block = test_utilities::make_mock_block(prev_block_hash);
+        let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
         let result: AddBlockEvent = blockchain.add_block(block.clone());
-        //println!("{:?}", result);
+        // println!("{:?}", result);
         assert_eq!(result, AddBlockEvent::AcceptedAsNewLongestChain);
 
         // make a 3rd fork by rolling back by 3 blocks
@@ -374,19 +381,50 @@ mod tests {
         let mut prev_block = blockchain.get_block_by_hash(&prev_block_hash).unwrap();
         prev_block_hash = prev_block.previous_block_hash().clone();
         prev_block = blockchain.get_block_by_hash(&prev_block_hash).unwrap();
-        prev_block_hash = prev_block.previous_block_hash().clone();
+        prev_block_hash = prev_block.hash().clone();
+        prev_block_id = prev_block.id();
 
-        for _n in 0..3 {
-            let block = test_utilities::make_mock_block(prev_block_hash);
+        for _n in 0..2 {
+            let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
             prev_block_hash = block.hash().clone();
+            prev_block_id = block.id();
             let result: AddBlockEvent = blockchain.add_block(block.clone());
             //println!("{:?}", result);
             assert_eq!(result, AddBlockEvent::Accepted);
         }
 
-        let block = test_utilities::make_mock_block(prev_block_hash);
+        let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
         let result: AddBlockEvent = blockchain.add_block(block.clone());
         //println!("{:?}", result);
         assert_eq!(result, AddBlockEvent::AcceptedAsNewLongestChain);
+
+        // make another fork
+        let block = test_utilities::make_mock_block(first_block_hash, 1);
+        let result: AddBlockEvent = blockchain.add_block(block.clone());
+        prev_block_hash = block.hash().clone();
+        prev_block_id = block.id();
+        //println!("{:?}", result);
+        assert_eq!(result, AddBlockEvent::Accepted);
+
+        // run 1000 blocks to test the epoch a bit
+        for _n in 0..1000 {
+            let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
+            prev_block_hash = block.hash().clone();
+            prev_block_id = block.id();
+            blockchain.add_block(block.clone());
+            //println!("{} {:?}", block.id(), result);
+        }
+
+        // TODO fix this problem:
+        // If you build on a fork which has an ancestor which is older than 2x EPOCH_LENGTH, the
+        // fork tree will happily accept the block but fork_chains will try to find an ancestor
+        // which is no longer present in the longest_chain_queue. The correct solution to this is
+        // to expire forks(delete all blocks from fork_tree) which have a common ancestor that is
+        // expiring(falling off the longest_chain_queue). Once this is done, the following code
+        // should simply return ParentNotFound instead of causing a panic.
+        // prev_block_hash = block.hash().clone();
+        // prev_block_id = block.id();
+        // let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
+        // let result: AddBlockEvent = blockchain.add_block(block.clone());
     }
 }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -135,7 +135,6 @@ impl Blockchain {
     /// These `AddBlockEvent`s will be turned into network responses so peers can figure out
     /// what's going on.
     pub fn add_block(&mut self, block: Block) -> AddBlockEvent {
-        println!("add block!!! {:?}", block.previous_block_hash());
         // TODO: Should we pass a serialized block [u8] to add_block instead of a Block?
         let is_first_block = block.previous_block_hash() == &[0u8; 32]
             && !self.contains_block_hash(block.previous_block_hash());
@@ -174,7 +173,6 @@ impl Blockchain {
                         // Wind up the new chain
 
                         new_chain.blocks.iter().rev().for_each(|block_hash| {
-                            println!("new chain hash: {:?}", block_hash);
                             let block = self.fork_tree.block_by_hash(block_hash).unwrap();
                             self.longest_chain_queue.roll_forward(block.hash());
                             self.utxoset.roll_forward(&block);
@@ -206,7 +204,6 @@ impl Blockchain {
 
         // If the previous block hash doesn't exist in the ForkTree, it's rejected
         if !self.fork_tree.contains_block_hash(previous_block_hash) {
-            println!("COULD NOT FIND PREVIOUS BLOCK!");
             return false;
         }
 
@@ -221,14 +218,12 @@ impl Blockchain {
                 previous_block.timestamp(),
             )
         {
-            println!("BURNFEE IS WRONG");
             return false;
         }
 
         // TODO: This should probably be >= but currently we are producing mock blocks very
         // quickly and this won't pass.
         if previous_block.timestamp() > block.timestamp() {
-            println!("INCORRECT TIMESTAMPS");
             return false;
         }
 
@@ -252,7 +247,6 @@ impl Blockchain {
             // make_message_from_bytes(&serialized_tx[..]);
             let hash_message = tx.core.hash();
             if !verify_message_signature(&hash_message, &tx.signature(), &(output_slip.address())) {
-                println!("SIGNATURE IS NOT VALID");
                 return false;
             };
 
@@ -264,7 +258,6 @@ impl Blockchain {
             });
 
             if !inputs_are_valid {
-                println!("INPUTS ARE NOT FVALID");
                 return false;
             }
 
@@ -284,7 +277,6 @@ impl Blockchain {
             let output_amt: u64 = tx.core.outputs().iter().map(|output| output.amount()).sum();
 
             if input_amt != output_amt {
-                println!("INPUTS DO NOT MATCH OUTPUTS");
                 return false;
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,6 @@ pub mod transaction;
 pub mod types;
 pub mod utxoset;
 
-#[macro_use]
-extern crate lazy_static;
-
 /// Error returned by most functions.
 ///
 /// When writing a real application, one might want to consider a specialized
@@ -60,7 +57,9 @@ pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;
 
 // TODO move this to another file and include!()
-// #[cfg(feature = "test-utilities")]
+// TODO put test_utilities behind a feature flag so it's not built into non-test builds
+//   i.e. uncomment this line:
+// [cfg(feature = "test-utilities")]
 pub mod test_utilities {
     use crate::block::Block;
     use crate::crypto::{make_message_from_bytes, Sha256Hash};
@@ -70,7 +69,7 @@ pub mod test_utilities {
     use crate::transaction::{Transaction, TransactionCore, TransactionType};
     // use secp256k1::Signature;
 
-    pub fn make_mock_block(previous_block_hash: Sha256Hash) -> Block {
+    pub fn make_mock_block(previous_block_hash: Sha256Hash, block_id: u64) -> Block {
         let keypair = Keypair::new();
         let from_slip = SlipID::default();
         let to_slip = OutputSlip::default();
@@ -89,6 +88,6 @@ pub mod test_utilities {
         // let tx2 = Transaction::default();
 
         // Block::new_mock(previous_block_hash, vec![tx.clone(), tx2.clone()])
-        Block::new_mock(previous_block_hash, vec![tx.clone()])
+        Block::new_mock(previous_block_hash, vec![tx.clone()], block_id)
     }
 }

--- a/src/longest_chain_queue.rs
+++ b/src/longest_chain_queue.rs
@@ -130,8 +130,6 @@ impl LongestChainQueue {
 #[cfg(test)]
 mod test {
     // use crate::keypair::Keypair;
-    use crate::crypto::make_message_from_string;
-    use crate::longest_chain_queue::LongestChainQueue;
 
     // #[test]
     // fn test_longest_chain_queue() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,27 @@
-use saito_rust::consensus;
-use tokio::signal;
+// use saito_rust::consensus;
+// use tokio::signal;
+use saito_rust::blockchain::{AddBlockEvent, Blockchain};
+use saito_rust::test_utilities;
+use std::{thread, time};
 
 #[tokio::main]
 pub async fn main() -> saito_rust::Result<()> {
-    consensus::run(signal::ctrl_c()).await
+    //consensus::run(signal::ctrl_c()).await
+    let mut blockchain = Blockchain::new();
+    let block = test_utilities::make_mock_block([0; 32], 0);
+    let mut prev_block_hash = block.hash().clone();
+    let mut prev_block_id = block.id();
+    let result: AddBlockEvent = blockchain.add_block(block.clone());
+    //println!("{:?}", result);
+    assert_eq!(result, AddBlockEvent::AcceptedAsLongestChain);
+    loop {
+        thread::sleep(time::Duration::from_millis(1000));
+
+        let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
+        prev_block_hash = block.hash().clone();
+        prev_block_id = block.id();
+        let result: AddBlockEvent = blockchain.add_block(block.clone());
+        println!("{:?}", result);
+    }
+    //Ok(())
 }


### PR DESCRIPTION
There was a panic caused by trying to add blocks beyond 2x epoch length because we were using block id 0 for all blocks and at some point block 0 would fall out of the longest_chain_queue. This change requires the block id to be the parent's id + 1 and adjusts the tests to comply with this. I also discovered a good test which can be seen in the last lines of blockchain.rs's tests that demo's a problem that will exist until we begin cleaning up old un-confirmed blocks from fork_tree.