### PR TITLE
Burnfee and Block Validation Refactor

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -44,7 +44,6 @@ impl Block {
             0,
             TREASURY,
             0.0,
-            0,
             0.0,
             transactions,
         );
@@ -60,10 +59,6 @@ impl Block {
         self.core.difficulty
     }
 
-    /// Returns the `Block` burnfee
-    pub fn burnfee(&self) -> u64 {
-        self.core.burnfee
-    }
     /// Returns the `BlockCore` of `Block`
     pub fn core(&self) -> &BlockCore {
         &self.core
@@ -157,8 +152,6 @@ pub struct BlockCore {
     treasury: u64,
     /// Start value in the `Burnfee` algorithm
     start_burnfee: f64,
-    /// `BurnFee` containing the fees paid to produce the block
-    burnfee: u64,
     /// Block difficulty required to win the `LotteryGame` in golden ticket generation
     difficulty: f32,
     /// simplified transaction cores
@@ -183,7 +176,6 @@ impl BlockCore {
             0,
             TREASURY,
             0.0,
-            0,
             0.0,
             &mut vec![],
         )
@@ -198,7 +190,6 @@ impl BlockCore {
         coinbase: u64,
         treasury: u64,
         start_burnfee: f64,
-        burnfee: u64,
         difficulty: f32,
         transactions: &mut Vec<Transaction>,
     ) -> Self {
@@ -210,7 +201,6 @@ impl BlockCore {
             coinbase,
             treasury,
             start_burnfee,
-            burnfee,
             difficulty,
             transactions: transactions.to_vec(),
         }
@@ -282,7 +272,6 @@ mod test {
         assert_eq!(block.previous_block_hash(), &[0; 32]);
         assert_eq!(block.creator(), public_key);
         assert_eq!(*block.transactions(), vec![]);
-        assert_eq!(block.burnfee(), 0);
         assert_eq!(block.difficulty(), 0.0);
         assert_eq!(block.coinbase(), 0);
         assert_eq!(block.start_burnfee(), 0.0);

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -278,15 +278,9 @@ impl Blockchain {
                     return true;
                 }
 
-                if let Some(output_slip) =
-                    self.utxoset.output_slip_from_slip_id(&tx.core.inputs()[0])
-                {
+                if let Some(address) = self.utxoset.get_receiver_for_slips(tx.core.inputs()) {
                     let hash_message = tx.core.hash();
-                    if !verify_message_signature(
-                        &hash_message,
-                        &tx.signature(),
-                        &(output_slip.address()),
-                    ) {
+                    if !verify_message_signature(&hash_message, &tx.signature(), address) {
                         println!("SIGNATURE IS NOT VALID");
                         return false;
                     };

--- a/src/burnfee.rs
+++ b/src/burnfee.rs
@@ -6,13 +6,6 @@ pub struct BurnFee {
 }
 
 impl BurnFee {
-    /// Returns the BurnFee used to calculate the work needed to produce a block
-    ///
-    /// * `start` - y-value at x = 0
-    pub fn new(start: f64) -> Self {
-        Self { start }
-    }
-
     /// Returns the amount of work needed to produce a block given the timestamp of
     /// the previous block, the current timestamp, and the y-axis of the burn fee
     /// curve. This is used both in the creation of blocks (mempool) as well as
@@ -22,21 +15,21 @@ impl BurnFee {
     /// * `current_block_timestamp`- candidate timestamp
     /// * `previous_block_timestamp` - timestamp of previous block
     pub fn return_work_needed(
-        &self,
+        start: f64,
         current_block_timestamp: u64,
         previous_block_timestamp: u64,
     ) -> u64 {
-        let mut elapsed_time = current_block_timestamp - previous_block_timestamp;
-        if elapsed_time == 0 {
-            elapsed_time = 1;
-        }
+        let elapsed_time = match current_block_timestamp - previous_block_timestamp {
+            0 => 1,
+            diff => diff,
+        };
+
         if elapsed_time >= (2 * HEARTBEAT) {
             return 0;
         }
 
         let elapsed_time_float = elapsed_time as f64;
-        let start_float = self.start as f64;
-        let work_needed_float: f64 = start_float / elapsed_time_float;
+        let work_needed_float: f64 = start / elapsed_time_float;
         let work_needed = work_needed_float * 100_000_000.0;
 
         return work_needed.round() as u64;
@@ -45,8 +38,12 @@ impl BurnFee {
     /// Returns an adjusted burnfee based on the start value provided
     /// and the difference between the current block timestamp and the
     /// previous block timestamp
-    pub fn burn_fee_adjustment(
-        &self,
+    ///
+    /// * `start` - The starting burn fee
+    /// * `current_block_timestamp` - The timestamp of the current `Block`
+    /// * `previous_block_timestamp` - The timestamp of the previous `Block`
+    pub fn burn_fee_adjustment_calculation(
+        start: f64,
         current_block_timestamp: u64,
         previous_block_timestamp: u64,
     ) -> f64 {
@@ -54,32 +51,7 @@ impl BurnFee {
             0 => 1,
             diff => diff,
         };
-        return self.start * ((HEARTBEAT) as f64 / (timestamp_difference) as f64).sqrt();
-    }
-
-    /// Adjusts the start value inside the `BurnFee` object based on
-    /// the provided timestamps
-    ///
-    /// * `current_block_timestamp` - Current `Block` timestamp
-    /// * `previous_block_timestamp` - Previous `Block` timestamp
-    pub fn adjust_work_needed(
-        &mut self,
-        current_block_timestamp: u64,
-        previous_block_timestamp: u64,
-    ) {
-        self.start = self.burn_fee_adjustment(current_block_timestamp, previous_block_timestamp);
-    }
-
-    pub fn burn_fee_calculation(
-        start: f64,
-        current_block_timestamp: u64,
-        previous_block_timestamp: u64,
-    ) -> u64 {
-        let timestamp_difference = match current_block_timestamp - previous_block_timestamp {
-            0 => 1,
-            diff => diff,
-        };
-        return (start * ((HEARTBEAT) as f64 / (timestamp_difference) as f64).sqrt()) as u64;
+        start * ((HEARTBEAT) as f64 / (timestamp_difference) as f64).sqrt()
     }
 }
 
@@ -88,35 +60,28 @@ mod tests {
     use super::*;
 
     #[test]
-    fn burnfee_test() {
-        let bf = BurnFee::new(10.0);
-        assert_eq!(bf.start, 10.0);
-    }
-
-    #[test]
     fn burnfee_return_work_needed_test() {
-        let bf = BurnFee::new(10.0);
-
         // if our elapsed time is twice our heartbeat, return 0
-        assert_eq!(bf.return_work_needed(2 * HEARTBEAT, 0), 0);
+        assert_eq!(BurnFee::return_work_needed(10.0, 2 * HEARTBEAT, 0), 0);
 
         // if their is no difference, the value should be the start value * 10^8
-        assert_eq!(bf.return_work_needed(0, 0), 10_0000_0000);
+        assert_eq!(BurnFee::return_work_needed(10.0, 0, 0), 10_0000_0000);
 
         // should return 1 * 10^8 * timestamp_diff
-        assert_eq!(bf.return_work_needed(HEARTBEAT / 3000, 0), 10000_0000);
+        assert_eq!(
+            BurnFee::return_work_needed(10.0, HEARTBEAT / 3000, 0),
+            10000_0000
+        );
     }
 
     #[test]
     fn burnfee_burn_fee_adjustment_test() {
         // if the difference in timestamps is equal to HEARTBEAT, our start value should not change
-        let bf = BurnFee::new(10.0);
-        assert_eq!(bf.burn_fee_adjustment(HEARTBEAT, 0), 10.0);
+        let mut new_start_burnfee = BurnFee::burn_fee_adjustment_calculation(10.0, HEARTBEAT, 0);
+        assert_eq!(new_start_burnfee, 10.0);
 
         // the difference should be the square root of HEARBEAT over the difference in timestamps
-        assert_eq!(
-            bf.burn_fee_adjustment(HEARTBEAT / 10, 0),
-            10.0 * (10.0 as f64).sqrt()
-        );
+        new_start_burnfee = BurnFee::burn_fee_adjustment_calculation(10.0, HEARTBEAT / 10, 0);
+        assert_eq!(new_start_burnfee, 10.0 * (10.0 as f64).sqrt());
     }
 }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -1,12 +1,15 @@
 use crate::{
+    blockchain::{AddBlockEvent, Blockchain},
     crypto::hash,
     golden_ticket::{generate_golden_ticket_transaction, generate_random_data},
     keypair::Keypair,
+    mempool::Mempool,
     types::SaitoMessage,
+    utxoset::UtxoSet,
 };
 use std::{
     future::Future,
-    sync::{Arc, RwLock},
+    sync::{Arc, Mutex, RwLock},
     thread::sleep,
     time::Duration,
 };
@@ -30,6 +33,7 @@ pub async fn run(shutdown: impl Future) -> crate::Result<()> {
     // purpose. The call below ignores the receiver of the broadcast pair, and when
     // a receiver is needed, the subscribe() method on the sender is used to create
     // one.
+
     let (notify_shutdown, _) = broadcast::channel(1);
     let (shutdown_complete_tx, shutdown_complete_rx) = mpsc::channel(1);
 
@@ -59,10 +63,15 @@ impl Consensus {
     /// Run consensus
     async fn _run(&mut self) -> crate::Result<()> {
         let (saito_message_tx, mut saito_message_rx) = broadcast::channel(32);
+
+        let block_tx = saito_message_tx.clone();
         let miner_tx = saito_message_tx.clone();
-        let mut miner_rx = saito_message_tx.subscribe();
 
         let keypair = Arc::new(RwLock::new(Keypair::new()));
+        let utxoset = Arc::new(Mutex::new(UtxoSet::new()));
+
+        let mut blockchain = Blockchain::new();
+        let mut mempool = Mempool::new(keypair.clone(), utxoset);
 
         tokio::spawn(async move {
             loop {
@@ -73,38 +82,39 @@ impl Consensus {
             }
         });
 
-        tokio::spawn(async move {
-            loop {
-                while let Ok(message) = miner_rx.recv().await {
-                    // simulate lottery game with creation of golden_ticket_transaction
-                    match message {
-                        SaitoMessage::Block { payload } => {
-                            let golden_tx = generate_golden_ticket_transaction(
-                                hash(&generate_random_data()),
-                                &payload,
-                                &keypair.read().unwrap(),
-                            );
-                            miner_tx
-                                .send(SaitoMessage::Transaction { payload: golden_tx })
-                                .unwrap();
-                        }
-                        _ => {}
-                    }
-                }
-            }
-        });
-
         loop {
-            while let Ok(_message) = saito_message_rx.recv().await {
+            while let Ok(message) = saito_message_rx.recv().await {
                 //
                 // TODO - "process" what? descriptive function name -- should fetch latest block not block index
                 //
-                // if let Some(block) = mempool.process(message, blockchain.get_latest_block()) {
-                //     blockchain.add_block(block.clone());
-                //     block_tx
-                //         .send(SaitoMessage::Block { payload: block })
-                //         .expect("Err: Could not send new block");
-                // }
+                match message {
+                    SaitoMessage::Block { payload } => {
+                        let golden_tx = generate_golden_ticket_transaction(
+                            hash(&generate_random_data()),
+                            &payload,
+                            &keypair.read().unwrap(),
+                        );
+
+                        miner_tx
+                            .send(SaitoMessage::Transaction { payload: golden_tx })
+                            .unwrap();
+                    }
+                    _ => {
+                        if let Some(block) = mempool.process(message, blockchain.latest_block()) {
+                            match blockchain.add_block(block.clone()) {
+                                AddBlockEvent::AcceptedAsLongestChain => {
+                                    block_tx
+                                        .send(SaitoMessage::Block { payload: block })
+                                        .unwrap();
+                                }
+                                fail_message => {
+                                    println!("WE MISSED LONGEST CHAIN, WHAT HAPPENED?");
+                                    println!("{:?}", fail_message)
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub type Result<T> = std::result::Result<T, Error>;
 // [cfg(feature = "test-utilities")]
 pub mod test_utilities {
     use crate::block::Block;
-    use crate::crypto::{make_message_from_bytes, Sha256Hash};
+    use crate::crypto::Sha256Hash;
     use crate::keypair::Keypair;
     use crate::slip::{OutputSlip, SlipID};
     use crate::time::create_timestamp;
@@ -80,14 +80,9 @@ pub mod test_utilities {
             TransactionType::Normal,
             vec![104, 101, 108, 108, 111],
         );
-        let message_bytes: Vec<u8> = tx_core.clone().into();
-        let message_hash = make_message_from_bytes(&message_bytes[..]);
-        let signature = keypair.sign_message(&message_hash[..]);
 
-        let tx = Transaction::add_signature(tx_core, signature);
-        // let tx2 = Transaction::default();
+        let tx = Transaction::create_signature(tx_core, &keypair);
 
-        // Block::new_mock(previous_block_hash, vec![tx.clone(), tx2.clone()])
-        Block::new_mock(previous_block_hash, vec![tx.clone()], block_id)
+        Block::new_mock(previous_block_hash, &mut vec![tx.clone()], block_id)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,7 @@
-// use saito_rust::consensus;
-// use tokio::signal;
-use saito_rust::blockchain::{AddBlockEvent, Blockchain};
-use saito_rust::test_utilities;
-use std::{thread, time};
+use saito_rust::consensus;
+use tokio::signal;
 
 #[tokio::main]
 pub async fn main() -> saito_rust::Result<()> {
-    //consensus::run(signal::ctrl_c()).await
-    let mut blockchain = Blockchain::new();
-    let block = test_utilities::make_mock_block([0; 32], 0);
-    let mut prev_block_hash = block.hash().clone();
-    let mut prev_block_id = block.id();
-    let result: AddBlockEvent = blockchain.add_block(block.clone());
-    //println!("{:?}", result);
-    assert_eq!(result, AddBlockEvent::AcceptedAsLongestChain);
-    loop {
-        thread::sleep(time::Duration::from_millis(1000));
-
-        let block = test_utilities::make_mock_block(prev_block_hash, prev_block_id + 1);
-        prev_block_hash = block.hash().clone();
-        prev_block_id = block.id();
-        let result: AddBlockEvent = blockchain.add_block(block.clone());
-        println!("{:?}", result);
-    }
-    //Ok(())
+    consensus::run(signal::ctrl_c()).await
 }

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,3 +1,17 @@
+use secp256k1::PublicKey;
+
+use crate::{
+    block::{Block, BlockCore, TREASURY},
+    burnfee::BurnFee,
+    keypair::Keypair,
+    time::{create_timestamp, format_timestamp},
+    transaction::Transaction,
+    types::SaitoMessage,
+    utxoset::UtxoSet,
+};
+
+use std::sync::{Arc, Mutex, RwLock};
+
 pub const GENESIS_PERIOD: u64 = 21500;
 
 /// The `Mempool` is the structure that collects blocks and transactions
@@ -6,166 +20,213 @@ pub const GENESIS_PERIOD: u64 = 21500;
 /// New `Block`s coming in over the network will hit the `Mempool` before being added to
 /// the `Blockchain`
 pub struct Mempool {
-    // /// A list of `Transaction`s to be bundled into `Block`s
-// transactions: Vec<Transaction>,
+    /// Keypair
+    keypair: Arc<RwLock<Keypair>>,
+    /// RefCell UTXoSet
+    _utxoset: Arc<Mutex<UtxoSet>>,
+    /// A list of `Transaction`s to be bundled into `Block`s
+    transactions: Vec<Transaction>,
 }
 
 impl Mempool {
-    // /// Creates new `Memppol`
-    // pub fn new(keypair: Arc<RwLock<Keypair>>) -> Self {
-    //     Mempool {
-    //         transactions: vec![],
-    //     }
-    // }
+    /// Creates new `Memppol`
+    pub fn new(keypair: Arc<RwLock<Keypair>>, utxoset: Arc<Mutex<UtxoSet>>) -> Self {
+        Mempool {
+            _utxoset: utxoset,
+            keypair,
+            transactions: vec![],
+        }
+    }
 
-    // /// Processes `SaitoMessage` and attempts to return `Block`
-    // ///
-    // /// * `message` - `SaitoMessage` enum commanding `Mempool` operation
-    // /// * `previous_block` - `Block` at longest chain position in `Blockchain`
-    // pub fn process(
-    //     &mut self,
-    //     message: SaitoMessage,
-    //     previous_block: &Block,
-    // ) -> Option<Block> {
-    //     match message {
-    //         SaitoMessage::Transaction { payload } => {
-    //             self.transactions.push(payload);
-    //             self.try_bundle(previous_block)
-    //         }
-    //         SaitoMessage::TryBundle => self.try_bundle(previous_block),
-    //         _ => None,
-    //     }
-    // }
+    /// Processes `SaitoMessage` and attempts to return `Block`
+    ///
+    /// * `message` - `SaitoMessage` enum commanding `Mempool` operation
+    /// * `previous_block` - `Block` at longest chain position in `Blockchain`
+    pub fn process(
+        &mut self,
+        message: SaitoMessage,
+        previous_block: Option<&Block>,
+    ) -> Option<Block> {
+        match message {
+            SaitoMessage::Transaction { payload } => {
+                self.transactions.push(payload);
+                self.try_bundle(previous_block)
+            }
+            SaitoMessage::TryBundle => self.try_bundle(previous_block),
+            _ => None,
+        }
+    }
 
-    // /// Attempt to create a new `Block`
-    // ///
-    // /// * `previous_block` - `Option` of previous `Block`
-    // fn try_bundle(&mut self, previous_block: &Block) -> Option<Block> {
-    //     if self.can_bundle_block(previous_block) {
-    //         Some(self.bundle_block(previous_block))
-    //     } else {
-    //         None
-    //     }
-    //     None
-    // }
+    /// Attempt to create a new `Block`
+    ///
+    /// * `previous_block` - `Option` of previous `Block`
+    fn try_bundle(&mut self, previous_block: Option<&Block>) -> Option<Block> {
+        if self.can_bundle_block(previous_block) {
+            Some(self.bundle_block(previous_block))
+        } else {
+            None
+        }
+    }
 
-    // /// Check to see if the `Mempool` has enough work to bundle a block
-    // ///
-    // /// * `previous_block` - `Option` of previous `Block`
-    // fn can_bundle_block(&self, previous_block: &Block) -> bool {
-    //     match previous_block {
-    //         Some((block_header, _)) => {
-    //             let current_timestamp = create_timestamp();
-    //             let work_needed = self
-    //                 ._burnfee
-    //                 .return_work_needed(current_timestamp, block_header.timestamp());
-    //
-    //             println!(
-    //                 "TS: {} -- WORK ---- {:?} -- {:?} --- TX COUNT {:?}",
-    //                 format_timestamp(current_timestamp),
-    //                 work_needed,
-    //                 self.work_available,
-    //                 self.transactions.len(),
-    //             );
-    //
-    //             // TODO -- add check for transactions in Mempool
-    //             self.work_available >= work_needed
-    //         }
-    //         None => true,
-    //         }
-    //     false
-    // }
+    /// Check to see if the `Mempool` has enough work to bundle a block
+    ///
+    /// * `previous_block` - `Option` of previous `Block`
+    fn can_bundle_block(&self, previous_block_option: Option<&Block>) -> bool {
+        match previous_block_option {
+            Some(previous_block) => {
+                let current_timestamp = create_timestamp();
+                let work_needed = BurnFee::return_work_needed(
+                    previous_block.start_burnfee(),
+                    current_timestamp,
+                    previous_block.timestamp(),
+                );
 
-    // /// Create a new `Block` from the `Mempool`'s list of `Transaction`s
-    // ///
-    // /// * `previous_block` - `Option` of the previous block on the longest chain
-    //     fn bundle_block(&mut self, previous_block: &Block) -> Block {
-    //
-    //         let keypair = self._keypair.read().unwrap();
-    //         let publickey = keypair.public_key();
-    //         let block: Block;
-    // /****
-    //         match previous_block_index {
-    //             Some((previous_block_header, previous_block_hash)) => {
-    //
-    //                 block = Block::new();
-    // 		//block.set_creator();
-    // 		//block.set_previous_block_hash();
-    //
-    //                 // TODO -- include reclaimed fees here
-    //                 //let treasury = previous_block_header.treasury();
-    //                 //let coinbase = (treasury as f64 / GENESIS_PERIOD as f64).round() as u64;
-    //
-    //                 block.set_id(previous_block_header.id() + 1);
-    //                 block.set_coinbase(coinbase);
-    //                 block.set_treasury(treasury - coinbase);
-    //                 block.set_previous_block_hash(previous_block_hash.clone());
-    //                 block.set_difficulty(previous_block_header.difficulty());
-    //
-    //                 self._burnfee
-    //                     .adjust_work_needed(block.timestamp(), previous_block_header.timestamp());
-    //                 block.set_burnfee(
-    //                     self._burnfee
-    //                         .return_work_needed(block.timestamp(), previous_block_header.timestamp()),
-    //                 );
-    //             }
-    //             None => {
-    //                 block = Block::new(publickey.clone(), [0; 32]);
-    //             }
-    //         }
-    //         block.set_transactions(&mut self.transactions);
-    // ****/
-    //
-    //         return block;
-    //         // TODO -- calculate difficulty and paysplit changes
-    //         // https://github.com/orgs/SaitoTech/projects/5#card-61347666
-    //     }
+                // TODO: re-add utxoset when it's decided on how we want to share mutable references
+                let work_available = 0;
+
+                println!(
+                    "TS: {} -- WORK ---- {:?} -- {:?} --- TX COUNT {:?}",
+                    format_timestamp(current_timestamp),
+                    work_needed,
+                    work_available,
+                    self.transactions.len(),
+                );
+
+                // TODO -- add check for transactions in Mempool
+                work_available >= work_needed
+            }
+            None => true,
+        }
+    }
+
+    /// Clear the transactions from the `Mempool`
+    fn clear_transactions(&mut self) {
+        self.transactions = vec![];
+    }
+
+    /// Create a new `Block` from the `Mempool`'s list of `Transaction`s
+    ///
+    /// * `previous_block` - `Option` of the previous block on the longest chain
+    fn bundle_block(&mut self, previous_block_option: Option<&Block>) -> Block {
+        let publickey: PublicKey;
+
+        {
+            let keypair = self.keypair.read().unwrap();
+            publickey = keypair.public_key().clone();
+        }
+
+        let block: Block;
+        let block_core: BlockCore;
+
+        match previous_block_option {
+            Some(previous_block) => {
+                let timestamp = create_timestamp();
+
+                let treasury = previous_block.treasury();
+                let coinbase = (treasury as f64 / GENESIS_PERIOD as f64).round() as u64;
+
+                block_core = BlockCore::new(
+                    previous_block.id() + 1,
+                    timestamp,
+                    previous_block.hash(),
+                    publickey,
+                    coinbase,
+                    treasury - coinbase,
+                    BurnFee::burn_fee_adjustment_calculation(
+                        previous_block.start_burnfee(),
+                        timestamp,
+                        previous_block.timestamp(),
+                    ),
+                    BurnFee::return_work_needed(
+                        previous_block.start_burnfee(),
+                        timestamp,
+                        previous_block.timestamp(),
+                    ),
+                    0.0,
+                    &mut self.transactions,
+                );
+
+                block = Block::new(block_core);
+
+                // TODO -- include reclaimed fees here
+            }
+            None => {
+                block_core = BlockCore::new(
+                    0,
+                    create_timestamp(),
+                    [0; 32],
+                    publickey.clone(),
+                    0,
+                    TREASURY,
+                    10.0,
+                    0,
+                    0.0,
+                    &mut vec![],
+                );
+
+                block = Block::new(block_core);
+            }
+        }
+        // TODO -- calculate difficulty and paysplit changes
+        // https://github.com/orgs/SaitoTech/projects/5#card-61347666
+
+        self.clear_transactions();
+
+        block
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    //
-    // use super::*;
-    // use crate::keypair::Keypair;
-    // use std::sync::{Arc, RwLock};
-    //
-    // #[test]
-    // fn mempool_test() {
-    //     assert_eq!(true, true);
-    //     let keypair = Arc::new(RwLock::new(Keypair::new()));
-    //     let mempool = Mempool::new(keypair);
-    //
-    //     assert_eq!(mempool.work_available, 0);
-    // }
-    // #[test]
-    // fn mempool_try_bundle_none_test() {
-    //     let keypair = Arc::new(RwLock::new(Keypair::new()));
-    //     let mut mempool = Mempool::new(keypair);
-    //
-    //     let new_block = mempool.try_bundle(None);
-    //
-    //     match new_block {
-    //         Some(block) => {
-    //             assert_eq!(block.id(), 0);
-    //             assert_eq!(*block.previous_block_hash(), [0; 32]);
-    //         }
-    //         None => {}
-    //     }
-    // }
-    // #[test]
-    // fn mempool_try_bundle_some_test() {
-    //     let keypair = Arc::new(RwLock::new(Keypair::new()));
-    //     let mut mempool = Mempool::new(keypair);
-    //
-    //     let prev_block = Block::new(Keypair::new().public_key().clone(), [0; 32]);
-    //     let prev_block_index = &(prev_block.header().clone(), prev_block.hash());
-    //     let new_block = mempool.try_bundle(Some(prev_block_index));
-    //
-    //     match new_block {
-    //         Some(_) => {}
-    //         None => {
-    //             assert_eq!(true, true)
-    //         }
-    //     }
-    // }
+
+    use super::*;
+    use crate::keypair::Keypair;
+    use crate::utxoset::UtxoSet;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn mempool_test() {
+        assert_eq!(true, true);
+        let keypair = Arc::new(RwLock::new(Keypair::new()));
+        let utxoset = Arc::new(Mutex::new(UtxoSet::new()));
+        let mempool = Mempool::new(keypair, utxoset);
+
+        assert_eq!(mempool.transactions, vec![]);
+    }
+
+    #[test]
+    fn mempool_try_bundle_none_test() {
+        let keypair = Arc::new(RwLock::new(Keypair::new()));
+        let utxoset = Arc::new(Mutex::new(UtxoSet::new()));
+        let mut mempool = Mempool::new(keypair, utxoset);
+
+        let new_block = mempool.try_bundle(None);
+
+        match new_block {
+            Some(block) => {
+                assert_eq!(block.id(), 0);
+                assert_eq!(*block.previous_block_hash(), [0; 32]);
+            }
+            None => {}
+        }
+    }
+
+    #[test]
+    fn mempool_try_bundle_some_test() {
+        let keypair = Arc::new(RwLock::new(Keypair::new()));
+        let utxoset = Arc::new(Mutex::new(UtxoSet::new()));
+        let mut mempool = Mempool::new(keypair, utxoset);
+
+        let core = BlockCore::default();
+        let prev_block = Block::new(core);
+
+        let new_block = mempool.try_bundle(Some(&prev_block));
+
+        match new_block {
+            Some(_) => {}
+            None => {
+                assert_eq!(true, true)
+            }
+        }
+    }
 }

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -137,11 +137,11 @@ impl Mempool {
                         timestamp,
                         previous_block.timestamp(),
                     ),
-                    BurnFee::return_work_needed(
-                        previous_block.start_burnfee(),
-                        timestamp,
-                        previous_block.timestamp(),
-                    ),
+                    // BurnFee::return_work_needed(
+                    //     previous_block.start_burnfee(),
+                    //     timestamp,
+                    //     previous_block.timestamp(),
+                    // ),
                     0.0,
                     &mut self.transactions,
                 );
@@ -159,7 +159,7 @@ impl Mempool {
                     0,
                     TREASURY,
                     10.0,
-                    0,
+                    // 0,
                     0.0,
                     &mut vec![],
                 );

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -86,15 +86,18 @@ mod test {
         let storage = Storage::new(Some(dir_path));
         let block = Block::default();
         let block_hash = block.hash();
+        println!("{:?}", block_hash);
         storage.write_block_to_disk(block).await.unwrap();
         match storage.read_block_from_disk(block_hash).await {
             Ok(_block) => {
                 assert!(true);
+                teardown().expect("Teardown failed");
             }
-            Err(_err) => {}
+            Err(_err) => {
+                teardown().expect("Teardown failed");
+            }
         }
 
         // TODO -- add unwind_panic to teardown when assert failes
-        teardown().expect("Teardown failed");
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,5 +1,6 @@
 use crate::{
     crypto::{make_message_from_bytes, Sha256Hash},
+    keypair::Keypair,
     slip::{OutputSlip, SlipID},
     time::create_timestamp,
 };
@@ -29,6 +30,7 @@ impl Hop {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Copy)]
 pub enum TransactionType {
     Normal,
+    GoldenTicket,
 }
 
 /// A record containging data of funds between transfered between public addresses. It
@@ -57,18 +59,6 @@ pub struct TransactionCore {
     /// A byte array of miscellaneous information
     message: Vec<u8>,
 }
-
-// impl From<Vec<u8>> for TransactionCore {
-//     fn from(data: Vec<u8>) -> Self {
-//         bincode::deserialize(&data[..]).unwrap()
-//     }
-// }
-//
-// impl Into<Vec<u8>> for TransactionCore {
-//     fn into(self) -> Vec<u8> {
-//         bincode::serialize(&self.core).unwrap()
-//     }
-// }
 
 impl Transaction {
     ///
@@ -109,6 +99,7 @@ impl Transaction {
         }
     }
 
+    /// Sign
     pub fn sign(core: TransactionCore) -> Transaction {
         Transaction {
             signature: Signature::from_compact(&[0; 64]).unwrap(),
@@ -116,6 +107,8 @@ impl Transaction {
             core: core,
         }
     }
+
+    /// Add a `Signature` to `Transaction`
     pub fn add_signature(core: TransactionCore, signature: Signature) -> Transaction {
         Transaction {
             signature: signature,
@@ -123,6 +116,15 @@ impl Transaction {
             core: core,
         }
     }
+
+    /// Create signature and new `Transaction`
+    pub fn create_signature(core: TransactionCore, keypair: &Keypair) -> Transaction {
+        let message_bytes: Vec<u8> = core.clone().into();
+        let message_hash = make_message_from_bytes(&message_bytes[..]);
+        let signature = keypair.sign_message(&message_hash[..]);
+        Transaction::add_signature(core, signature)
+    }
+
     /// Returns `secp256k1::Signature` verifying the validity of data on a transaction
     pub fn signature(&self) -> &Signature {
         &self.signature
@@ -172,6 +174,17 @@ impl Into<Vec<u8>> for TransactionCore {
 }
 
 impl TransactionCore {
+    /// Default `TransactionCore` creation
+    pub fn default() -> Self {
+        TransactionCore {
+            timestamp: create_timestamp(),
+            inputs: vec![],
+            outputs: vec![],
+            broadcast_type: TransactionType::Normal,
+            message: vec![],
+        }
+    }
+
     /// Creates new `Transaction`
     ///
     /// * `broadcast_type` - `TransactionType` of the new `Transaction`
@@ -240,6 +253,14 @@ impl TransactionCore {
         // TODO get rid of this clone
         let serialized_tx: Vec<u8> = self.clone().into();
         make_message_from_bytes(&serialized_tx[..])
+    }
+
+    pub fn set_type(&mut self, tx_type: TransactionType) {
+        self.broadcast_type = tx_type;
+    }
+
+    pub fn set_message(&mut self, message: Vec<u8>) {
+        self.message = message;
     }
 }
 

--- a/src/utxoset.rs
+++ b/src/utxoset.rs
@@ -204,14 +204,30 @@ impl UtxoSet {
     /// a single address, and, if so, returns that address, otherwise returns None. This is used
     /// to validate that the signer of a transaction is the receiver of all the outputs which
     /// he/she is trying to spend as inputs in a transaction.
-    pub fn get_receiver_for_slips(&self, _slip_ids: Vec<SlipID>) -> Option<PublicKey> {
-        Some(
-            PublicKey::from_str(
-                "0225ee90fc71570613b42e29912a760bb0b2da9182b2a4271af9541b7c5e278072",
-            )
-            .unwrap(),
-        )
+    pub fn get_receiver_for_slips(&self, slip_ids: &Vec<SlipID>) -> Option<&PublicKey> {
+        if slip_ids.is_empty() {
+            None
+        } else {
+            if let Some(outputs) = slip_ids
+                .iter()
+                .map(|input| self.output_slip_from_slip_id(input))
+                .collect::<Option<Vec<&OutputSlip>>>()
+            {
+                let first = outputs[0];
+                if outputs
+                    .iter()
+                    .all(|&output| output.address() == first.address())
+                {
+                    Some(first.address())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        }
     }
+
     /// This is used to get the Output(`OutputSlip`) which corresponds to a given Input(`SlipID`)
     pub fn output_slip_from_slip_id(&self, slip_id: &SlipID) -> Option<&OutputSlip> {
         match self.shashmap.get(slip_id) {


### PR DESCRIPTION
Apologies for the massive PR, but this was split off from our `add_block` work and deserved a seperate PR.

In this PR, we
- Change `Block` to contain `difficulty` and `start_burnfee` inside `BlockCore` instead of at the high level
- Simplify how BurnFee operates, reintroduce `start_burnfee` for validation purposes
- Introduce different transaction validation for `Normal` and `GoldenTicket` transactions
- Simplify how `consensus` is running