### PR TITLE
feat: use global arc<mutex<blockchain>> for shared state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 /data
+/src/data
 *.swp
-/data/blocks/*.sai

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,9 @@ pub mod transaction;
 pub mod types;
 pub mod utxoset;
 
+#[macro_use]
+extern crate lazy_static;
+
 /// Error returned by most functions.
 ///
 /// When writing a real application, one might want to consider a specialized


### PR DESCRIPTION
It is proving very difficult to use a thread_local blockchain object which also allows async functions.

We don't want to restrict ourselves to only writing non-async functions because this will only get harder and harder to fix as we move forward.

thread_local's .with(|| {...} ) requires a closure. Async closures are unstable in rust. It may be possible to enable async closure or to use an FnOnce function instead of a closure, but this is tricky to get working, is holding us back, and can probably be classified as premature optimization.

If we instead simply use a lazy_static for getting global reference to the blockchain object, this isn't a problem. It may even end up being faster, although this depends on how much tokio benefits from having access to multiple threads vs how much cost we pay for using atomics.

Once this is merged, we should refactor add_block to be async.

