### PR TITLE
chore: set default bin for rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,10 @@ authors = [
     "Stephen Peterkins <stephen@saito.tech>"
 ]
 edition = "2018"
+default-run = "saito_rust"
 
 [[bin]]
-name = "saito-spammer"
+name = "saito_spammer"
 path = "src/bin/spammer.rs"
 
 [dependencies]


### PR DESCRIPTION
Without a default bin this happens:  
```bash
cargo run
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: saito-spammer, saito_rust
```

Renaming `saito-spammer` to `saito_spammer` because of the `saito_rust` naming