### PR TITLE
wallet class and keypair in crypto class

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,22 +1,62 @@
-pub use secp256k1::{Message, PublicKey, Signature, SECP256K1};
+pub use secp256k1::{Message, SecretKey, PublicKey, Signature, SECP256K1};
 use sha2::{Digest, Sha256};
 use std::convert::TryInto;
-
+use base58::ToBase58;
+use hex::{decode_to_slice};
 //
 // forward-looking flexibility
 //
 pub type SaitoHash = [u8; 32];
 pub type SaitoPublicKey = [u8; 33];
+pub type SaitoPrivateKey = [u8; 32]; // 256-bit key
 pub type SaitoSignature = [u8; 64];
 
+
+//
+// The Keypair is a crypto-class object that holds the secp256k1 private
+// and publickey. Not all external functions hold both private and public
+// keys. On the blockchain most publickeys are stored in byte-array format
+// and never touch a keypair.
+//
+pub struct Keypair {
+  privatekey: SecretKey,
+  publickey: PublicKey,
+}
+impl Keypair {
+
+    pub fn new() -> Keypair {
+        let (mut secret_key, mut public_key) = SECP256K1.generate_keypair(&mut secp256k1::rand::thread_rng());
+        while public_key.serialize().to_base58().len() != 44 {
+            // sometimes secp256k1 address is too big to store in 44 base-58 digits
+            let keypair_tuple = SECP256K1.generate_keypair(&mut secp256k1::rand::thread_rng());
+            secret_key = keypair_tuple.0;
+            public_key = keypair_tuple.1;
+        }
+
+        Keypair {
+	    publickey: public_key,
+	    privatekey: secret_key,
+        }
+    }
+
+    pub fn get_privatekey(&self) -> SaitoPrivateKey {
+        let mut secret_bytes = [0u8; 32];
+        let _res = decode_to_slice(self.privatekey.as_ref(), &mut secret_bytes as &mut [u8]);
+	secret_bytes
+    }
+
+    pub fn get_publickey(&self) -> SaitoPublicKey {
+	self.publickey.serialize()
+    }
+
+}
 
 pub fn hash(data: &Vec<u8>) -> SaitoHash {
     let mut hasher = Sha256::new();
     hasher.update(data);
     hasher.finalize().as_slice().try_into().unwrap()
-    //let results : [u8;32] = hasher.finalize().as_slice().try_into().unwrap()
-    //hasher.finalize().try_into().expect("hash is wrong size")
 }
+
 
 pub fn verify(msg: &[u8], sig: SaitoSignature, publickey: SaitoPublicKey) -> bool {
     let m = Message::from_slice(msg).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod network;
 pub mod slip;
 pub mod time;
 pub mod transaction;
+pub mod wallet;
 
 
 extern crate lazy_static;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,0 +1,146 @@
+use crate::consensus::SaitoMessage;
+use crate::crypto::{SaitoPublicKey, SaitoPrivateKey, Keypair};
+use ::std::{sync::Arc, thread::sleep, time::Duration};
+use tokio::sync::{broadcast, mpsc, RwLock};
+
+#[derive(Clone, Debug)]
+pub enum WalletMessage {
+    TestMessage,
+    TestMessage2,
+}
+
+/// The `Wallet` manages the public and private keypair of the node and holds the
+/// slips that are used to form transactions on the network.
+pub struct Wallet {
+
+    broadcast_channel_sender: Option<broadcast::Sender<SaitoMessage>>,
+    wallet_channel_sender: Option<mpsc::Sender<WalletMessage>>,
+
+    keypair: Keypair,
+
+}
+
+impl Wallet {
+
+    pub fn new() -> Self {
+        Wallet {
+            broadcast_channel_sender: None,
+            wallet_channel_sender: None,
+	    keypair: Keypair::new(),
+        }
+    }
+
+    pub fn get_publickey(&self) -> SaitoPublicKey {
+        self.keypair.get_publickey()
+    }
+
+    pub fn get_privatekey(&self) -> SaitoPrivateKey {
+        self.keypair.get_privatekey()
+    }
+
+    pub fn set_broadcast_channel_sender(&mut self, bcs : broadcast::Sender<SaitoMessage>) {
+      self.broadcast_channel_sender = Some(bcs);
+    }
+    pub fn set_wallet_channel_sender(&mut self, wcs : mpsc::Sender<WalletMessage>) {
+      self.wallet_channel_sender = Some(wcs);
+    }
+
+}
+
+
+
+
+
+
+
+
+
+//
+// This function is called on initialization to setup the sending
+// and receiving channels for asynchronous loops or message checks
+//
+pub async fn run(
+    wallet_lock: Arc<RwLock<Wallet>>,
+    broadcast_channel_sender: broadcast::Sender<SaitoMessage>,
+    mut broadcast_channel_receiver: broadcast::Receiver<SaitoMessage>,
+) -> crate::Result<()> {
+    let (wallet_channel_sender, mut wallet_channel_receiver) = mpsc::channel(4);
+
+    //
+    // pass clones of our broadcast sender channels into Wallet so it 
+    // can broadcast into the world as well...
+    //
+    {
+        let mut wallet = wallet_lock.write().await;
+        wallet.set_broadcast_channel_sender(broadcast_channel_sender.clone());
+        wallet.set_wallet_channel_sender(wallet_channel_sender.clone());
+    }
+
+    //
+    // loops to trigger messages
+    //
+    tokio::spawn(async move {
+        loop {
+            wallet_channel_sender
+                .send(WalletMessage::TestMessage)
+                .await
+                .expect("error: Wallet TestMessage failed to send");
+            sleep(Duration::from_millis(5000));
+        }
+    });
+
+
+    loop {
+        tokio::select! {
+
+      	    //
+	    // local messages
+	    //
+            Some(message) = wallet_channel_receiver.recv() => {
+                match message {
+		    //
+		    // TestMessage
+		    //
+		    // test if our local broadcast loop is working by printing
+		    // a confirmation message when we receive a WalletMessage::
+		    // TestMessage.
+		    //
+                    WalletMessage::TestMessage => {
+			println!("Wallet has received local TestMessage broadcast");
+                    },
+		    _ => {}
+                }
+            }
+
+
+      	    //
+	    // system-wide messages
+	    //
+            Ok(message) = broadcast_channel_receiver.recv() => {
+                match message {
+		    //
+		    // BlockchainAddBlock
+		    //
+		    // triggered when the blockchain has validated and added 
+		    // a new block. This examines the block for any transactions
+		    // relevant to our wallet.
+		    //
+                    //SaitoMessage::MempoolNewBlock { hash } => {
+                    //}
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn wallet_new_test() {
+        assert_eq!(true, true);
+    }
+
+}
+


### PR DESCRIPTION
This creates a generic wallet that works exactly like the mempool.
 - private channel for in-wallet messages
 - ability to listen on and public system-wide broadcasts
 
This pushes the Keypair INTO the crypto-class as part of our efforts to contain anything that touches algorithm-specific code to that class. The wallet has a copy, but gets_ the standard bytes-array data. We may want to think about not storing the Keypair in the wallet at all.