### PR TITLE
fix: de/serialize big arrays

### DIFF
--- a/src/big_array.rs
+++ b/src/big_array.rs
@@ -1,0 +1,70 @@
+use serde::de::{Deserialize, Deserializer, Error, SeqAccess, Visitor};
+use serde::ser::{Serialize, SerializeTuple, Serializer};
+use std::fmt;
+use std::marker::PhantomData;
+
+pub trait BigArray<'de>: Sized {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer;
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>;
+}
+
+macro_rules! big_array {
+    ($($len:expr,)+) => {
+        $(
+            impl<'de, T> BigArray<'de> for [T; $len]
+                where T: Default + Copy + Serialize + Deserialize<'de>
+            {
+                fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+                    where S: Serializer
+                {
+                    let mut seq = serializer.serialize_tuple(self.len())?;
+                    for elem in &self[..] {
+                        seq.serialize_element(elem)?;
+                    }
+                    seq.end()
+                }
+
+                fn deserialize<D>(deserializer: D) -> Result<[T; $len], D::Error>
+                    where D: Deserializer<'de>
+                {
+                    struct ArrayVisitor<T> {
+                        element: PhantomData<T>,
+                    }
+
+                    impl<'de, T> Visitor<'de> for ArrayVisitor<T>
+                        where T: Default + Copy + Deserialize<'de>
+                    {
+                        type Value = [T; $len];
+
+                        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                            formatter.write_str(concat!("an array of length ", $len))
+                        }
+
+                        fn visit_seq<A>(self, mut seq: A) -> Result<[T; $len], A::Error>
+                            where A: SeqAccess<'de>
+                        {
+                            let mut arr = [T::default(); $len];
+                            for i in 0..$len {
+                                arr[i] = seq.next_element()?
+                                    .ok_or_else(|| Error::invalid_length(i, &self))?;
+                            }
+                            Ok(arr)
+                        }
+                    }
+
+                    let visitor = ArrayVisitor { element: PhantomData };
+                    deserializer.deserialize_tuple($len, visitor)
+                }
+            }
+        )+
+    }
+}
+
+big_array! {
+    33, 40, 48, 50, 56, 64, 72, 96, 100, 128, 160, 192, 200, 224, 256, 384, 512,
+    768, 1024, 2048, 4096, 8192, 16384, 32768, 65536,
+}

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,4 +1,5 @@
 use crate::{
+    big_array::BigArray,
     crypto::{hash, SaitoHash, SaitoPublicKey, SaitoSignature},
     time::create_timestamp,
     transaction::Transaction,
@@ -19,10 +20,10 @@ pub struct BlockCore {
     id: u64,
     timestamp: u64,
     previous_block_hash: SaitoHash,
-    #[serde_as(as = "[_; 33]")]
+    #[serde(with = "BigArray")]
     creator: SaitoPublicKey, // public key of block creator
     merkle_root: SaitoHash, // merkle root of txs
-    #[serde_as(as = "[_; 64]")]
+    #[serde(with = "BigArray")]
     signature: SaitoSignature, // signature of block creator
     treasury: u64,
     burnfee: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ The Saito Team
 dev@saito.tech
 
 */
+pub mod big_array;
 pub mod block;
 pub mod blockchain;
 pub mod consensus;

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -1,3 +1,4 @@
+use crate::big_array::BigArray;
 use crate::crypto::{SaitoPublicKey, SaitoSignature};
 use serde::{Deserialize, Serialize};
 
@@ -20,9 +21,9 @@ pub enum SlipType {
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SlipCore {
-    #[serde_as(as = "[_; 33]")]
+    #[serde(with = "BigArray")]
     publickey: SaitoPublicKey,
-    #[serde_as(as = "[_; 64]")]
+    #[serde(with = "BigArray")]
     uuid: SaitoSignature,
     amount: u64,
     slip_ordinal: u8,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,4 +1,4 @@
-use crate::{crypto::SaitoSignature, slip::Slip, time::create_timestamp};
+use crate::{big_array::BigArray, crypto::SaitoSignature, slip::Slip, time::create_timestamp};
 use serde::{Deserialize, Serialize};
 
 /// TransactionType is a human-readable indicator of the type of
@@ -27,7 +27,7 @@ pub struct TransactionCore {
     #[serde(with = "serde_bytes")]
     message: Vec<u8>,
     transaction_type: TransactionType,
-    #[serde_as(as = "[_; 64]")]
+    #[serde(with = "BigArray")]
     signature: SaitoSignature, // compact signatures are 64 bytes; DER signatures are 68-72 bytes
 }
 
@@ -59,7 +59,7 @@ impl Default for TransactionCore {
             vec![],
             vec![],
             TransactionType::Normal,
-            [0;64],
+            [0; 64],
         )
     }
 }
@@ -119,7 +119,7 @@ impl Transaction {
         self.core.message = message;
     }
 
-    pub fn set_signature(&mut self, sig : SaitoSignature) {
+    pub fn set_signature(&mut self, sig: SaitoSignature) {
         self.core.signature = sig;
     }
 }
@@ -148,13 +148,20 @@ mod tests {
     #[test]
     fn transaction_core_new_test() {
         let timestamp = create_timestamp();
-        let tx_core = TransactionCore::new(timestamp, vec![], vec![], vec![], TransactionType::Normal, [0;64]);
+        let tx_core = TransactionCore::new(
+            timestamp,
+            vec![],
+            vec![],
+            vec![],
+            TransactionType::Normal,
+            [0; 64],
+        );
         assert_eq!(tx_core.timestamp, timestamp);
         assert_eq!(tx_core.inputs, vec![]);
         assert_eq!(tx_core.outputs, vec![]);
         assert_eq!(tx_core.message, Vec::<u8>::new());
         assert_eq!(tx_core.transaction_type, TransactionType::Normal);
-        assert_eq!(tx_core.signature, [0;64]);
+        assert_eq!(tx_core.signature, [0; 64]);
     }
 
     #[test]


### PR DESCRIPTION
Fixed build by implementing de/serialize for big arrays.
`#[serde_as(as = "[_; 33]")]` does not work when the array size is larger than 32 so we have to manually implement it.