### PR TITLE
Refactor: demoted Wallet with limited access to private key 

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -8,17 +8,18 @@ pub type SaitoPublicKey = [u8; 33];
 pub type SaitoPrivateKey = [u8; 32]; // 256-bit key
 pub type SaitoSignature = [u8; 64];
 
-//
-// The Keypair is a crypto-class object that holds the secp256k1 private
-// and publickey. Not all external functions hold both private and public
-// keys. On the blockchain most publickeys are stored in byte-array format
-// and never touch a keypair.
-//
+/// The Keypair is a crypto-class object that holds the secp256k1 private
+/// and publickey. Not all external functions hold both private and public
+/// keys. On the blockchain most publickeys are stored in byte-array format
+/// and never touch a keypair.
+#[derive(Clone, Debug)]
 pub struct Keypair {
     privatekey: SecretKey,
     publickey: PublicKey,
 }
+
 impl Keypair {
+    #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Keypair {
         let (mut secret_key, mut public_key) =
             SECP256K1.generate_keypair(&mut secp256k1::rand::thread_rng());
@@ -35,16 +36,14 @@ impl Keypair {
         }
     }
 
-    pub fn get_privatekey(&self) -> SaitoPrivateKey {
-        let mut secret_bytes = [0u8; 32];
-        for i in 0..32 {
-            secret_bytes[i] = self.privatekey[i];
-        }
-        return secret_bytes;
-    }
-
     pub fn get_publickey(&self) -> SaitoPublicKey {
         self.publickey.serialize()
+    }
+
+    pub fn sign(&self, message_bytes: &[u8]) -> SaitoSignature {
+        let msg = Message::from_slice(message_bytes).unwrap();
+        let sig = SECP256K1.sign(&msg, &self.privatekey);
+        sig.serialize_compact()
     }
 }
 
@@ -52,13 +51,6 @@ pub fn hash(data: &Vec<u8>) -> SaitoHash {
     let mut hasher = Sha256::new();
     hasher.update(data);
     hasher.finalize().as_slice().try_into().unwrap()
-}
-
-pub fn sign(message_bytes: &[u8], privatekey: SaitoPrivateKey) -> SaitoSignature {
-    let msg = Message::from_slice(message_bytes).unwrap();
-    let secret = SecretKey::from_slice(&privatekey).unwrap();
-    let sig = SECP256K1.sign(&msg, &secret);
-    return sig.serialize_compact();
 }
 
 pub fn verify(msg: &[u8], sig: SaitoSignature, publickey: SaitoPublicKey) -> bool {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -59,7 +59,7 @@ impl Default for TransactionCore {
             vec![],
             vec![],
             TransactionType::Normal,
-            [0;64],
+            [0; 64],
         )
     }
 }
@@ -119,7 +119,7 @@ impl Transaction {
         self.core.message = message;
     }
 
-    pub fn set_signature(&mut self, sig : SaitoSignature) {
+    pub fn set_signature(&mut self, sig: SaitoSignature) {
         self.core.signature = sig;
     }
 }
@@ -148,13 +148,20 @@ mod tests {
     #[test]
     fn transaction_core_new_test() {
         let timestamp = create_timestamp();
-        let tx_core = TransactionCore::new(timestamp, vec![], vec![], vec![], TransactionType::Normal, [0;64]);
+        let tx_core = TransactionCore::new(
+            timestamp,
+            vec![],
+            vec![],
+            vec![],
+            TransactionType::Normal,
+            [0; 64],
+        );
         assert_eq!(tx_core.timestamp, timestamp);
         assert_eq!(tx_core.inputs, vec![]);
         assert_eq!(tx_core.outputs, vec![]);
         assert_eq!(tx_core.message, Vec::<u8>::new());
         assert_eq!(tx_core.transaction_type, TransactionType::Normal);
-        assert_eq!(tx_core.signature, [0;64]);
+        assert_eq!(tx_core.signature, [0; 64]);
     }
 
     #[test]

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,28 +1,16 @@
-use crate::consensus::SaitoMessage;
-use crate::crypto::{Keypair, SaitoPrivateKey, SaitoPublicKey};
-use ::std::{sync::Arc, thread::sleep, time::Duration};
-use tokio::sync::{broadcast, mpsc, RwLock};
-
-#[derive(Clone, Debug)]
-pub enum WalletMessage {
-    TestMessage,
-    TestMessage2,
-}
+use crate::crypto::{Keypair, SaitoPublicKey, SaitoSignature};
 
 /// The `Wallet` manages the public and private keypair of the node and holds the
 /// slips that are used to form transactions on the network.
+#[derive(Clone, Debug)]
 pub struct Wallet {
-    broadcast_channel_sender: Option<broadcast::Sender<SaitoMessage>>,
-    wallet_channel_sender: Option<mpsc::Sender<WalletMessage>>,
-
     keypair: Keypair,
 }
 
 impl Wallet {
+    #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Self {
         Wallet {
-            broadcast_channel_sender: None,
-            wallet_channel_sender: None,
             keypair: Keypair::new(),
         }
     }
@@ -31,93 +19,8 @@ impl Wallet {
         self.keypair.get_publickey()
     }
 
-    pub fn get_privatekey(&self) -> SaitoPrivateKey {
-        self.keypair.get_privatekey()
-    }
-
-    pub fn set_broadcast_channel_sender(&mut self, bcs: broadcast::Sender<SaitoMessage>) {
-        self.broadcast_channel_sender = Some(bcs);
-    }
-    pub fn set_wallet_channel_sender(&mut self, wcs: mpsc::Sender<WalletMessage>) {
-        self.wallet_channel_sender = Some(wcs);
-    }
-}
-
-//
-// This function is called on initialization to setup the sending
-// and receiving channels for asynchronous loops or message checks
-//
-pub async fn run(
-    wallet_lock: Arc<RwLock<Wallet>>,
-    broadcast_channel_sender: broadcast::Sender<SaitoMessage>,
-    mut broadcast_channel_receiver: broadcast::Receiver<SaitoMessage>,
-) -> crate::Result<()> {
-    let (wallet_channel_sender, mut wallet_channel_receiver) = mpsc::channel(4);
-
-    //
-    // pass clones of our broadcast sender channels into Wallet so it
-    // can broadcast into the world as well...
-    //
-    {
-        let mut wallet = wallet_lock.write().await;
-        wallet.set_broadcast_channel_sender(broadcast_channel_sender.clone());
-        wallet.set_wallet_channel_sender(wallet_channel_sender.clone());
-    }
-
-    //
-    // loops to trigger messages
-    //
-    tokio::spawn(async move {
-        loop {
-            wallet_channel_sender
-                .send(WalletMessage::TestMessage)
-                .await
-                .expect("error: Wallet TestMessage failed to send");
-            sleep(Duration::from_millis(5000));
-        }
-    });
-
-    loop {
-        tokio::select! {
-
-              //
-        // local messages
-        //
-            Some(message) = wallet_channel_receiver.recv() => {
-                match message {
-            //
-            // TestMessage
-            //
-            // test if our local broadcast loop is working by printing
-            // a confirmation message when we receive a WalletMessage::
-            // TestMessage.
-            //
-                    WalletMessage::TestMessage => {
-            println!("Wallet has received local TestMessage broadcast");
-                    },
-            _ => {}
-                }
-            }
-
-
-              //
-        // system-wide messages
-        //
-            Ok(message) = broadcast_channel_receiver.recv() => {
-                match message {
-            //
-            // BlockchainAddBlock
-            //
-            // triggered when the blockchain has validated and added
-            // a new block. This examines the block for any transactions
-            // relevant to our wallet.
-            //
-                    //SaitoMessage::MempoolNewBlock { hash } => {
-                    //}
-                    _ => {}
-                }
-            }
-        }
+    pub fn sign(&self, message_bytes: &[u8]) -> SaitoSignature {
+        self.keypair.sign(message_bytes)
     }
 }
 


### PR DESCRIPTION
A few thoughts:

- Wallet can be passed as a local attribute for both `Mempool`, `Blockchain` and other parts of the program
- It does not need a `run` function, all write operations can be done within `Blockchain`
- Access to `privatekey` should be hidden within `Keypair` inside `Wallet`. It's a security concern to pass around a node's private key all over the program
- Therefore, `sign` should be moved out of crypto and strictly into `Wallet`. The access problem is solved by passing `Wallet` as a reference widely to parts of the program that need it