### PR TITLE
Feature: use blake3 for hashing algorithm with parallel hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,6 +81,22 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake3"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64485778c4f16a6a5a9d335e80d449ac6c70cdd6a06d2af18a6f6f775a125b3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 0.1.10",
+ "constant_time_eq",
+ "crypto-mac",
+ "digest",
+ "rayon",
+]
 
 [[package]]
 name = "block-buffer"
@@ -136,6 +164,12 @@ checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -172,6 +206,12 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cpufeatures"
@@ -224,7 +264,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -234,7 +274,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -245,7 +285,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -258,8 +298,18 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+dependencies = [
+ "generic-array",
+ "subtle",
 ]
 
 [[package]]
@@ -441,7 +491,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -452,7 +502,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -628,7 +678,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -722,7 +772,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -884,7 +934,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -1294,6 +1344,7 @@ dependencies = [
  "ahash",
  "base58",
  "bincode",
+ "blake3",
  "chrono",
  "criterion",
  "hex",
@@ -1306,7 +1357,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1464,20 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
  "block-buffer",
- "cfg-if",
- "cpufeatures",
- "digest",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
-dependencies = [
- "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -1530,6 +1567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+
+[[package]]
 name = "syn"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,7 +1589,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "rand 0.8.4",
  "redox_syscall",
@@ -1688,7 +1731,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -1935,7 +1978,7 @@ version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ serde_with = "1.9.4"
 bincode = "1.3"
 chrono = "0.4"
 secp256k1 = { version = "0.20.3", features = ["global-context", "serde"] }
-sha2 = "0.9.5"
+blake3 = { version = "0.3.8", features = ["rayon"] }
 base58 = "0.1.0"
 hex = "0.4.3"
 jemallocator = "0.1.9"

--- a/src/block.rs
+++ b/src/block.rs
@@ -153,8 +153,8 @@ impl Block {
         self.core.creator = creator;
     }
 
-    pub fn set_merkle_root(&mut self, merkle_root : SaitoHash) {
-	self.core.merkle_root = merkle_root;
+    pub fn set_merkle_root(&mut self, merkle_root: SaitoHash) {
+        self.core.merkle_root = merkle_root;
     }
 
     // TODO - signature needs to be generated from consensus vars
@@ -172,11 +172,9 @@ impl Block {
         self.core.difficulty = difficulty;
     }
 
-    pub fn set_hash(&mut self, hash : SaitoHash) {
-	self.hash = hash;
+    pub fn set_hash(&mut self, hash: SaitoHash) {
+        self.hash = hash;
     }
-
-
 
     // TODO
     //
@@ -187,39 +185,32 @@ impl Block {
     // for blockchain functions.
     //
     pub fn generate_hash(&mut self) -> SaitoHash {
-
         //
         // fastest known way that isn't bincode ??
         //
-        let mut vbytes : Vec<u8> = vec![];
-                vbytes.extend(&self.core.id.to_be_bytes());
-                vbytes.extend(&self.core.timestamp.to_be_bytes());
-                vbytes.extend(&self.core.previous_block_hash);
-                vbytes.extend(&self.core.creator);
-                vbytes.extend(&self.core.merkle_root);
-                vbytes.extend(&self.core.signature);
-                vbytes.extend(&self.core.treasury.to_be_bytes());
-                vbytes.extend(&self.core.burnfee.to_be_bytes());
-                vbytes.extend(&self.core.difficulty.to_be_bytes());
+        let mut vbytes: Vec<u8> = vec![];
+        vbytes.extend(&self.core.id.to_be_bytes());
+        vbytes.extend(&self.core.timestamp.to_be_bytes());
+        vbytes.extend(&self.core.previous_block_hash);
+        vbytes.extend(&self.core.creator);
+        vbytes.extend(&self.core.merkle_root);
+        vbytes.extend(&self.core.signature);
+        vbytes.extend(&self.core.treasury.to_be_bytes());
+        vbytes.extend(&self.core.burnfee.to_be_bytes());
+        vbytes.extend(&self.core.difficulty.to_be_bytes());
 
-	hash(&vbytes)
-
+        hash(&vbytes[..])
     }
+
     pub fn generate_merkle_root(&mut self) -> SaitoHash {
-	[0;32]
+        [0; 32]
     }
-
 
     pub fn validate(&self) -> bool {
-
-        let _transactions_valid = &self.transactions
-            .par_iter()
-            .all(|tx| tx.validate());
+        let _transactions_valid = &self.transactions.par_iter().all(|tx| tx.validate());
 
         return true;
-
     }
-
 }
 
 impl Default for Block {

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -23,7 +23,7 @@ impl Blockchain {
             block.get_hash()
         );
 
-	println!("Validates? {:?}", block.validate());
+        println!("Validates? {:?}", block.validate());
     }
 
     pub fn get_latest_block(&self) -> Option<&Block> {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,12 +1,13 @@
 use base58::ToBase58;
+use blake3::{join::RayonJoin, Hasher};
 pub use secp256k1::{Message, PublicKey, SecretKey, Signature, SECP256K1};
-use sha2::{Digest, Sha256};
-use std::convert::TryInto;
 
 pub type SaitoHash = [u8; 32];
 pub type SaitoPublicKey = [u8; 33];
 pub type SaitoPrivateKey = [u8; 32]; // 256-bit key
 pub type SaitoSignature = [u8; 64];
+
+pub const PARALLEL_HASH_BYTE_THRESHOLD: usize = 128_000;
 
 //
 // The Keypair is a crypto-class object that holds the secp256k1 private
@@ -48,10 +49,17 @@ impl Keypair {
     }
 }
 
-pub fn hash(data: &Vec<u8>) -> SaitoHash {
-    let mut hasher = Sha256::new();
-    hasher.update(data);
-    hasher.finalize().as_slice().try_into().unwrap()
+pub fn hash(data: &[u8]) -> SaitoHash {
+    let mut hasher = Hasher::new();
+    // Hashing in parallel can be faster if large enough
+    // TODO: Blake3 has benchmarked 128 kb as the cutoff,
+    // the benchmark should be redone for Saito's needs
+    if data.len() > PARALLEL_HASH_BYTE_THRESHOLD {
+        hasher.update(data);
+    } else {
+        hasher.update_with_join::<RayonJoin>(data);
+    }
+    hasher.finalize().into()
 }
 
 pub fn sign(message_bytes: &[u8], privatekey: SaitoPrivateKey) -> SaitoSignature {
@@ -67,6 +75,3 @@ pub fn verify(msg: &[u8], sig: SaitoSignature, publickey: SaitoPublicKey) -> boo
     let s = Signature::from_compact(&sig).unwrap();
     SECP256K1.verify(&m, &s, &p).is_ok()
 }
-
-
-

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -2,7 +2,7 @@ use crate::{
     block::Block,
     blockchain::Blockchain,
     consensus::SaitoMessage,
-    crypto::{SaitoHash, SaitoPrivateKey, SaitoPublicKey, hash, verify},
+    crypto::{hash, verify, SaitoHash, SaitoPrivateKey, SaitoPublicKey},
     slip::Slip,
     transaction::Transaction,
     wallet::Wallet,
@@ -77,9 +77,9 @@ impl Mempool {
         block.set_id(previous_block_id);
         block.set_previous_block_hash(previous_block_hash);
         let block_hash = block.generate_hash();
-	block.set_hash(block_hash);
+        block.set_hash(block_hash);
         let block_merkle_root = block.generate_merkle_root();
-	block.set_merkle_root(block_merkle_root);
+        block.set_merkle_root(block_merkle_root);
 
         for _i in 0..1000 {
             let mut transaction = Transaction::default();
@@ -99,24 +99,23 @@ impl Mempool {
             transaction.add_input(input1);
             transaction.add_output(output1);
 
-	    // sign ...
+            // sign ...
             transaction.sign(creator_privatekey);
             let tx_sig = transaction.get_signature();
 
-   	    // ... and verify
+            // ... and verify
             let vbytes = transaction.serialize_for_signature();
-            let hash = hash(&vbytes);
+            let hash = hash(&vbytes[..]);
             let v = verify(&hash, tx_sig, creator_publickey);
-	    if !v {
-println!("Transaction does not Validate: {:?}", v);
-	    }
-
+            if !v {
+                println!("Transaction does not Validate: {:?}", v);
+            }
         }
 
         block
     }
 }
- 
+
 // This function is called on initialization to setup the sending
 // and receiving channels for asynchronous loops or message checks
 pub async fn run(

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -115,7 +115,6 @@ impl Slip {
     pub fn validate(&self) -> bool {
         return true;
     }
-
 }
 
 impl Default for Slip {


### PR DESCRIPTION
These numbers speak for themselves:

![Benchmark](https://raw.githubusercontent.com/BLAKE3-team/BLAKE3/037de38bfec4e813ab6189a50cb7c4cbae47268a/media/speed.svg)

Orders of magnitude increase in speed without any major differences in security in comparison to sha2.

Additionally, blake3 allows us to hash in parallel. Based on their own benchmarks, inputs over 128 kb show improvements in speed when parallelized. This would be excellent in speeding up signature creation/verification for `Transaction`s