### PR TITLE
Sequential refactor blockring and blockchain add block

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,10 +1,11 @@
 use crate::{
     big_array::BigArray,
-    crypto::{hash, SaitoHash, SaitoPublicKey, SaitoSignature},
+    crypto::{hash, SaitoHash, SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey},
     time::create_timestamp,
     transaction::Transaction,
 };
 use serde::{Deserialize, Serialize};
+use ahash::AHashMap;
 
 extern crate rayon;
 use rayon::prelude::*;
@@ -102,6 +103,10 @@ impl Block {
         self.hash
     }
 
+    pub fn get_lc(&self) -> bool {
+        self.lc
+    }
+
     pub fn get_id(&self) -> u64 {
         self.core.id
     }
@@ -110,7 +115,7 @@ impl Block {
         self.core.timestamp
     }
 
-    pub fn previous_block_hash(&self) -> SaitoHash {
+    pub fn get_previous_block_hash(&self) -> SaitoHash {
         self.core.previous_block_hash
     }
 
@@ -140,6 +145,10 @@ impl Block {
 
     pub fn set_id(&mut self, id: u64) {
         self.core.id = id;
+    }
+
+    pub fn set_lc(&mut self, lc : bool) {
+        self.lc = lc;
     }
 
     pub fn set_timestamp(&mut self, timestamp: u64) {
@@ -206,6 +215,16 @@ impl Block {
     pub fn generate_merkle_root(&mut self) -> SaitoHash {
         [0; 32]
     }
+
+    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, longest_chain : bool) -> bool {
+
+        for tx in &self.transactions {
+            tx.on_chain_reorganization(utxoset, longest_chain, self.get_id());
+        }
+        return true;
+
+    }
+
 
     pub fn validate(&self) -> bool {
         let _transactions_valid = &self.transactions.par_iter().all(|tx| tx.validate());

--- a/src/block.rs
+++ b/src/block.rs
@@ -4,8 +4,8 @@ use crate::{
     time::create_timestamp,
     transaction::Transaction,
 };
-use serde::{Deserialize, Serialize};
 use ahash::AHashMap;
+use serde::{Deserialize, Serialize};
 
 extern crate rayon;
 use rayon::prelude::*;
@@ -147,7 +147,7 @@ impl Block {
         self.core.id = id;
     }
 
-    pub fn set_lc(&mut self, lc : bool) {
+    pub fn set_lc(&mut self, lc: bool) {
         self.lc = lc;
     }
 
@@ -216,15 +216,16 @@ impl Block {
         [0; 32]
     }
 
-    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, longest_chain : bool) -> bool {
-
+    pub fn on_chain_reorganization(
+        &self,
+        utxoset: &mut AHashMap<SaitoUTXOSetKey, u64>,
+        longest_chain: bool,
+    ) -> bool {
         for tx in &self.transactions {
             tx.on_chain_reorganization(utxoset, longest_chain, self.get_id());
         }
         return true;
-
     }
-
 
     pub fn validate(&self) -> bool {
         let _transactions_valid = &self.transactions.par_iter().all(|tx| tx.validate());

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,14 +1,15 @@
 use crate::block::Block;
 use crate::blockring::BlockRing;
-use crate::crypto::SaitoHash;
+use crate::crypto::{SaitoHash, SaitoUTXOSetKey};
+use crate::time::{create_timestamp};
 
 use ahash::AHashMap;
 
 #[derive(Debug)]
 pub struct Blockchain {
+    utxoset: AHashMap<SaitoUTXOSetKey, u64>,
     blockring: BlockRing,
     blocks: AHashMap<SaitoHash, Block>,
-    last_block_hash: Option<SaitoHash>,
 }
 
 
@@ -17,39 +18,318 @@ impl Blockchain {
     #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Self {
         Blockchain {
+	    utxoset: AHashMap::new(),
     	    blockring: BlockRing::new(),
             blocks: AHashMap::new(),
-            last_block_hash: None,
         }
     }
+
 
     pub fn add_block(&mut self, block: Block) {
-        println!(
-            "Received block in blockchain.add_block: {:?}",
-            block.get_hash()
-        );
 
-        println!("Validates? {:?}", block.validate());
+println!(" ... add_block start: {:?}", create_timestamp());
+
+        //
+        // start by extracting some variables that we will use
+	// repeatedly in the course of adding this block to the
+	// blockchain and our various indices.
+        //
+        let block_hash = block.get_hash();
+        let block_id = block.get_id();
+	let previous_block_hash = self.blockring.get_longest_chain_block_hash();
+
+        //
+        // sanity checks
+        //
+        //println!("Block Hash: {:?}", block.get_hash());
+
+
+	//
+	// pre-validation
+	//
+	// this would be a great place to put in a prevalidation check
+	// once we are finished implementing Saito Classic. Goal would 
+	// be a fast form of lite-validation just to determine that it
+	// is worth going through the more general effort of evaluating
+	// this block for consensus.
+	//
+
+
+        //
+	// save block to disk
+	//
+	// we have traditionally saved blocks to disk AFTER validating them
+	// but this can slow down block propagation. So it may be sensible
+	// to start a save earlier-on in the process so that we can relay
+	// the block faster serving it off-disk instead of fetching it 
+	// repeatedly from memory. Exactly when to do this is left as an
+	// optimization exercise.
+	//
+
+
+        //
+        // insert block into hashmap and index
+        //
+	// the blockring is a BlockRing which lets us know which blocks (at which depth) 
+	// form part of the longest-chain. We also use the BlockRing to track information
+	// on network congestion (how many block candidates exist at various depths and 
+	// in the future potentially the amount of work on each viable fork chain.
+	// 
+	// we are going to transfer ownership of the block into the HashMap that stores
+	// the block next, so we insert it into our BlockRing first as that will avoid
+	// needing to borrow the value back for insertion into the BlockRing.
+	// 
+        if !self.blockring.contains_block_hash_at_block_id(block_id, block_hash) {
+            self.blockring.add_block(&block);
+        }
+	//
+	// blocks are stored in a hashmap indexed by the block_hash. we expect all
+	// all block_hashes to be unique, so simply insert blocks one-by-one on 
+	// arrival if they do not exist.
+	// 
+        if !self.blocks.contains_key(&block_hash) { 
+	    self.blocks.insert(block_hash, block); 
+	}
+
+
+
+        //
+        // now find the shared ancestor
+        //
+        let mut new_chain: Vec<[u8;32]> = Vec::new();
+        let mut old_chain: Vec<[u8;32]> = Vec::new();
+        let mut shared_ancestor_found = false;
+        let mut new_chain_hash = block_hash;
+        let mut old_chain_hash = previous_block_hash;
+
+
+        //
+        // find the shared ancestor of our proposed chain
+        //
+        while !shared_ancestor_found {
+            if self.blocks.contains_key(&new_chain_hash) {
+                new_chain.push(new_chain_hash);
+                new_chain_hash = self.blocks.get(&new_chain_hash).unwrap().get_previous_block_hash();
+                if new_chain_hash == [0;32] { break; }
+                if self.blocks.get(&new_chain_hash).unwrap().get_lc() {
+                    shared_ancestor_found = true;
+                }
+            } else {
+                break;
+            }
+
+        }
+
+
+        //
+        // and fill in the old_chain if it exists
+        //
+        if shared_ancestor_found {
+            loop {
+
+                if new_chain_hash == old_chain_hash {
+                    break;
+                }
+                if self.blocks.contains_key(&old_chain_hash) {
+                    old_chain.push(old_chain_hash);
+                    old_chain_hash = self.blocks.get(&old_chain_hash).unwrap().get_previous_block_hash();
+                    if old_chain_hash == [0;32] {
+                        break;
+                    }
+                    if new_chain_hash == old_chain_hash {
+                        break;
+                    }
+                }
+
+            }
+        }
+
+println!("new chain: {:?}", new_chain);
+println!("old chain: {:?}", old_chain);
+
+        //
+        // at this point we should have a shared ancestor
+        //
+	// find out whether this new block is claiming to require chain-validation
+	//
+        let am_i_the_longest_chain = self.is_new_chain_the_longest_chain(&new_chain, &old_chain);
+
+
+
+	//
+	// if this is a potential longest-chain candidate, validate
+	//
+
+        //
+        // validate
+        //
+        if am_i_the_longest_chain {
+println!(" ... start validate:  {:?}", create_timestamp());
+            let does_new_chain_validate = self.validate(new_chain, old_chain);
+println!(" ... finish validate: {:?}", create_timestamp());
+            if does_new_chain_validate {
+println!("SUCCESS");
+                self.add_block_success(block_hash);
+            } else {
+println!("FAILURE 1");
+                self.add_block_failure();
+            }
+println!("does the new chain validate: {}", does_new_chain_validate);
+        } else {
+println!("FAILURE 2");
+            self.add_block_failure();
+        }
+
+
+
+
+
+
+println!("is this the longest chain: {:?}", am_i_the_longest_chain);
+
+
+//        println!("Validates? {:?}", block.validate());
     }
 
+
+
+
+    pub fn add_block_success(&mut self, block_hash: SaitoHash) {
+
+        //
+        // block is longest-chain
+        //
+        // mutable update is hell -- we can do this but have to have
+        // manually checked that the entry exists in order to pull
+        // this trick. we did this check before validating.
+        //
+        self.blocks.get_mut(&block_hash).unwrap().set_lc(true);
+
+    }
+    pub fn add_block_failure(&mut self) {
+
+    }
+
+
+
+
+
     pub fn get_latest_block(&self) -> Option<&Block> {
-        match self.last_block_hash {
-            Some(hash) => self.blocks.get(&hash),
-            None => None,
-        }
+	let block_hash = self.blockring.get_longest_chain_block_hash();	
+        if self.blocks.contains_key(&block_hash) {
+	    return self.blocks.get(&block_hash);
+	}
+	return None;
     }
 
     pub fn get_latest_block_hash(&self) -> SaitoHash {
-        match self.last_block_hash {
-            Some(hash) => self.blocks.get(&hash).unwrap().get_hash(),
-            None => [0; 32],
-        }
+	return self.blockring.get_longest_chain_block_hash();	
     }
 
     pub fn get_latest_block_id(&self) -> u64 {
-        match self.last_block_hash {
-            Some(hash) => self.blocks.get(&hash).unwrap().get_id(),
-            None => 1,
+	return self.blockring.get_longest_chain_block_id();	
+    }
+
+
+    pub fn is_new_chain_the_longest_chain(&mut self, new_chain: &Vec<[u8;32]>, old_chain: &Vec<[u8;32]>) -> bool {
+
+        if old_chain.len() > new_chain.len() { return false; }
+
+        let mut old_bf = 0;
+        let mut new_bf = 0;
+        for hash in old_chain.iter() { old_bf += self.blocks.get(hash).unwrap().get_burnfee(); }
+        for hash in new_chain.iter() { new_bf += self.blocks.get(hash).unwrap().get_burnfee(); }
+
+	//
+	// new chain must have more accumulated work AND be longer
+	//
+        if old_chain.len() < new_chain.len() && old_bf < new_bf {
+            return true;
+        }
+
+        return false;
+    }
+
+
+    pub fn validate(&mut self, new_chain: Vec<[u8;32]>, old_chain: Vec<[u8;32]>) -> bool {
+        if old_chain.len() > 0 {
+            return self.unwind_chain(&new_chain, &old_chain, old_chain.len()-1, false);
+        } else if new_chain.len() > 0 {
+            return self.wind_chain(&new_chain, &old_chain, 0, false);
+        }
+        return true;
+    }
+
+
+    pub fn wind_chain(&mut self, new_chain: &Vec<[u8;32]>, old_chain: &Vec<[u8;32]>, current_wind_index: usize, wind_failure: bool) -> bool {
+
+        let block = &self.blocks[&new_chain[current_wind_index]];
+
+        //
+        // validate the block
+        //
+        let does_block_validate = block.validate();
+
+        if does_block_validate {
+            block.on_chain_reorganization(&mut self.utxoset, true);
+            if current_wind_index == (new_chain.len()-1) {
+                if wind_failure { return false }
+                return true;
+            }
+            return self.wind_chain(new_chain, old_chain, current_wind_index+1, false);
+        } else {
+
+            //
+            // tough luck, go back to the old chain
+            //
+            if current_wind_index == 0 {
+
+                //
+                // this is the first block we have tried to add
+                // and so we can just roll out the older chain
+                // again as it is known good.
+                //
+                // note that old and new hashes are swapped
+                // and the old chain is set as null because
+                // we won't move back to it. we also set the
+                // resetting_flag to 1 so we know to fork
+                // into addBlockToBlockchainFailure
+                //
+                // true -> force -> we had issues, is failure
+                //
+                return self.wind_chain(old_chain, new_chain, 0, true);
+
+            } else {
+
+                let mut chain_to_unwind : Vec<[u8;32]> = vec![];
+                for i in current_wind_index..new_chain.len() {
+                    chain_to_unwind.push(new_chain[i].clone());
+                }
+                return self.unwind_chain(old_chain, &chain_to_unwind, chain_to_unwind.len()-1, true);
+            }
         }
     }
+
+    pub fn unwind_chain(&mut self, new_chain: &Vec<[u8;32]>, old_chain: &Vec<[u8;32]>, current_unwind_index: usize, wind_failure : bool) -> bool {
+
+        let block = &self.blocks[&old_chain[current_unwind_index]];
+
+        block.on_chain_reorganization(&mut self.utxoset, false);
+
+        if current_unwind_index == 0 {
+            //
+            // start winding new chain
+            //
+            return self.wind_chain(new_chain, old_chain, 0, false);
+        } else {
+            //
+            // continue unwinding
+            //
+            return self.unwind_chain(new_chain, old_chain, current_unwind_index-1, false);
+        }
+
+    }
+
+
+
 }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,9 +1,12 @@
 use crate::block::Block;
+use crate::blockring::BlockRing;
 use crate::crypto::SaitoHash;
+
 use ahash::AHashMap;
 
 #[derive(Debug)]
 pub struct Blockchain {
+    blockring: BlockRing,
     blocks: AHashMap<SaitoHash, Block>,
     last_block_hash: Option<SaitoHash>,
 }
@@ -14,6 +17,7 @@ impl Blockchain {
     #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Self {
         Blockchain {
+    	    blockring: BlockRing::new(),
             blocks: AHashMap::new(),
             last_block_hash: None,
         }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1,7 +1,7 @@
 use crate::block::Block;
 use crate::blockring::BlockRing;
 use crate::crypto::{SaitoHash, SaitoUTXOSetKey};
-use crate::time::{create_timestamp};
+use crate::time::create_timestamp;
 
 use ahash::AHashMap;
 
@@ -12,91 +12,86 @@ pub struct Blockchain {
     blocks: AHashMap<SaitoHash, Block>,
 }
 
-
-
 impl Blockchain {
     #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Self {
         Blockchain {
-	    utxoset: AHashMap::new(),
-    	    blockring: BlockRing::new(),
+            utxoset: AHashMap::new(),
+            blockring: BlockRing::new(),
             blocks: AHashMap::new(),
         }
     }
 
-
     pub fn add_block(&mut self, block: Block) {
-
-println!(" ... add_block start: {:?}", create_timestamp());
+        println!(" ... add_block start: {:?}", create_timestamp());
 
         //
         // start by extracting some variables that we will use
-	// repeatedly in the course of adding this block to the
-	// blockchain and our various indices.
+        // repeatedly in the course of adding this block to the
+        // blockchain and our various indices.
         //
         let block_hash = block.get_hash();
         let block_id = block.get_id();
-	let previous_block_hash = self.blockring.get_longest_chain_block_hash();
+        let previous_block_hash = self.blockring.get_longest_chain_block_hash();
 
         //
         // sanity checks
         //
         //println!("Block Hash: {:?}", block.get_hash());
 
-
-	//
-	// pre-validation
-	//
-	// this would be a great place to put in a prevalidation check
-	// once we are finished implementing Saito Classic. Goal would 
-	// be a fast form of lite-validation just to determine that it
-	// is worth going through the more general effort of evaluating
-	// this block for consensus.
-	//
-
+        //
+        // pre-validation
+        //
+        // this would be a great place to put in a prevalidation check
+        // once we are finished implementing Saito Classic. Goal would
+        // be a fast form of lite-validation just to determine that it
+        // is worth going through the more general effort of evaluating
+        // this block for consensus.
+        //
 
         //
-	// save block to disk
-	//
-	// we have traditionally saved blocks to disk AFTER validating them
-	// but this can slow down block propagation. So it may be sensible
-	// to start a save earlier-on in the process so that we can relay
-	// the block faster serving it off-disk instead of fetching it 
-	// repeatedly from memory. Exactly when to do this is left as an
-	// optimization exercise.
-	//
-
+        // save block to disk
+        //
+        // we have traditionally saved blocks to disk AFTER validating them
+        // but this can slow down block propagation. So it may be sensible
+        // to start a save earlier-on in the process so that we can relay
+        // the block faster serving it off-disk instead of fetching it
+        // repeatedly from memory. Exactly when to do this is left as an
+        // optimization exercise.
+        //
 
         //
         // insert block into hashmap and index
         //
-	// the blockring is a BlockRing which lets us know which blocks (at which depth) 
-	// form part of the longest-chain. We also use the BlockRing to track information
-	// on network congestion (how many block candidates exist at various depths and 
-	// in the future potentially the amount of work on each viable fork chain.
-	// 
-	// we are going to transfer ownership of the block into the HashMap that stores
-	// the block next, so we insert it into our BlockRing first as that will avoid
-	// needing to borrow the value back for insertion into the BlockRing.
-	// 
-        if !self.blockring.contains_block_hash_at_block_id(block_id, block_hash) {
+        // the blockring is a BlockRing which lets us know which blocks (at which depth)
+        // form part of the longest-chain. We also use the BlockRing to track information
+        // on network congestion (how many block candidates exist at various depths and
+        // in the future potentially the amount of work on each viable fork chain.
+        //
+        // we are going to transfer ownership of the block into the HashMap that stores
+        // the block next, so we insert it into our BlockRing first as that will avoid
+        // needing to borrow the value back for insertion into the BlockRing.
+        //
+        if !self
+            .blockring
+            .contains_block_hash_at_block_id(block_id, block_hash)
+        {
             self.blockring.add_block(&block);
         }
-	//
-	// blocks are stored in a hashmap indexed by the block_hash. we expect all
-	// all block_hashes to be unique, so simply insert blocks one-by-one on 
-	// arrival if they do not exist.
-	// 
-        if !self.blocks.contains_key(&block_hash) { 
-	    self.blocks.insert(block_hash, block); 
-	}
-
+        //
+        // blocks are stored in a hashmap indexed by the block_hash. we expect all
+        // all block_hashes to be unique, so simply insert blocks one-by-one on
+        // arrival if they do not exist.
+        //
+        if !self.blocks.contains_key(&block_hash) {
+            self.blocks.insert(block_hash, block);
+        }
 
         //
         // find shared ancestor of new_block with old_chain
         //
-        let mut new_chain: Vec<[u8;32]> = Vec::new();
-        let mut old_chain: Vec<[u8;32]> = Vec::new();
+        let mut new_chain: Vec<[u8; 32]> = Vec::new();
+        let mut old_chain: Vec<[u8; 32]> = Vec::new();
         let mut shared_ancestor_found = false;
         let mut new_chain_hash = block_hash;
         let mut old_chain_hash = previous_block_hash;
@@ -104,63 +99,68 @@ println!(" ... add_block start: {:?}", create_timestamp());
         while !shared_ancestor_found {
             if self.blocks.contains_key(&new_chain_hash) {
                 new_chain.push(new_chain_hash);
-                new_chain_hash = self.blocks.get(&new_chain_hash).unwrap().get_previous_block_hash();
-                if new_chain_hash == [0;32] { break; }
+                new_chain_hash = self
+                    .blocks
+                    .get(&new_chain_hash)
+                    .unwrap()
+                    .get_previous_block_hash();
+                if new_chain_hash == [0; 32] {
+                    break;
+                }
                 if self.blocks.get(&new_chain_hash).unwrap().get_lc() {
                     shared_ancestor_found = true;
                 }
             } else {
                 break;
             }
-
         }
-
 
         //
         // and get existing current chain for comparison
         //
         if shared_ancestor_found {
             loop {
-
                 if new_chain_hash == old_chain_hash {
                     break;
                 }
                 if self.blocks.contains_key(&old_chain_hash) {
                     old_chain.push(old_chain_hash);
-                    old_chain_hash = self.blocks.get(&old_chain_hash).unwrap().get_previous_block_hash();
-                    if old_chain_hash == [0;32] {
+                    old_chain_hash = self
+                        .blocks
+                        .get(&old_chain_hash)
+                        .unwrap()
+                        .get_previous_block_hash();
+                    if old_chain_hash == [0; 32] {
                         break;
                     }
                     if new_chain_hash == old_chain_hash {
                         break;
                     }
                 }
-
             }
         }
 
-//println!("new chain: {:?}", new_chain);
-//println!("old chain: {:?}", old_chain);
+        //println!("new chain: {:?}", new_chain);
+        //println!("old chain: {:?}", old_chain);
 
         //
         // at this point we should have a shared ancestor
         //
-	// find out whether this new block is claiming to require chain-validation
-	//
+        // find out whether this new block is claiming to require chain-validation
+        //
         let am_i_the_longest_chain = self.is_new_chain_the_longest_chain(&new_chain, &old_chain);
 
-
-	//
-	// if this is a potential longest-chain candidate, validate
-	//
+        //
+        // if this is a potential longest-chain candidate, validate
+        //
 
         //
         // validate
         //
         if am_i_the_longest_chain {
-println!(" ... start validate:  {:?}", create_timestamp());
+            println!(" ... start validate:  {:?}", create_timestamp());
             let does_new_chain_validate = self.validate(new_chain, old_chain);
-println!(" ... finish validate: {:?}", create_timestamp());
+            println!(" ... finish validate: {:?}", create_timestamp());
             if does_new_chain_validate {
                 self.add_block_success(block_hash);
             } else {
@@ -170,18 +170,13 @@ println!(" ... finish validate: {:?}", create_timestamp());
             self.add_block_failure();
         }
 
-println!("TOTAL INDEX OF BLOCKS");
-self.blockring.print_lc();
-
+        println!("TOTAL INDEX OF BLOCKS");
+        self.blockring.print_lc();
     }
 
-
-
-
     pub fn add_block_success(&mut self, block_hash: SaitoHash) {
-
-	//
-	// TODO - 
+        //
+        // TODO -
         //
         // block is longest-chain
         //
@@ -190,45 +185,46 @@ self.blockring.print_lc();
         // this trick. we did this check before validating.
         //
         self.blocks.get_mut(&block_hash).unwrap().set_lc(true);
-
     }
-    pub fn add_block_failure(&mut self) {
-
-    }
-
-
-
-
+    pub fn add_block_failure(&mut self) {}
 
     pub fn get_latest_block(&self) -> Option<&Block> {
-	let block_hash = self.blockring.get_longest_chain_block_hash();	
+        let block_hash = self.blockring.get_longest_chain_block_hash();
         if self.blocks.contains_key(&block_hash) {
-	    return self.blocks.get(&block_hash);
-	}
-	return None;
+            return self.blocks.get(&block_hash);
+        }
+        return None;
     }
 
     pub fn get_latest_block_hash(&self) -> SaitoHash {
-	return self.blockring.get_longest_chain_block_hash();	
+        return self.blockring.get_longest_chain_block_hash();
     }
 
     pub fn get_latest_block_id(&self) -> u64 {
-	return self.blockring.get_longest_chain_block_id();	
+        return self.blockring.get_longest_chain_block_id();
     }
 
-
-    pub fn is_new_chain_the_longest_chain(&mut self, new_chain: &Vec<[u8;32]>, old_chain: &Vec<[u8;32]>) -> bool {
-
-        if old_chain.len() > new_chain.len() { return false; }
+    pub fn is_new_chain_the_longest_chain(
+        &mut self,
+        new_chain: &Vec<[u8; 32]>,
+        old_chain: &Vec<[u8; 32]>,
+    ) -> bool {
+        if old_chain.len() > new_chain.len() {
+            return false;
+        }
 
         let mut old_bf = 0;
         let mut new_bf = 0;
-        for hash in old_chain.iter() { old_bf += self.blocks.get(hash).unwrap().get_burnfee(); }
-        for hash in new_chain.iter() { new_bf += self.blocks.get(hash).unwrap().get_burnfee(); }
+        for hash in old_chain.iter() {
+            old_bf += self.blocks.get(hash).unwrap().get_burnfee();
+        }
+        for hash in new_chain.iter() {
+            new_bf += self.blocks.get(hash).unwrap().get_burnfee();
+        }
 
-	//
-	// new chain must have more accumulated work AND be longer
-	//
+        //
+        // new chain must have more accumulated work AND be longer
+        //
         if old_chain.len() < new_chain.len() && old_bf <= new_bf {
             return true;
         }
@@ -236,19 +232,22 @@ self.blockring.print_lc();
         return false;
     }
 
-
-    pub fn validate(&mut self, new_chain: Vec<[u8;32]>, old_chain: Vec<[u8;32]>) -> bool {
+    pub fn validate(&mut self, new_chain: Vec<[u8; 32]>, old_chain: Vec<[u8; 32]>) -> bool {
         if old_chain.len() > 0 {
-            return self.unwind_chain(&new_chain, &old_chain, old_chain.len()-1, false);
+            return self.unwind_chain(&new_chain, &old_chain, old_chain.len() - 1, false);
         } else if new_chain.len() > 0 {
             return self.wind_chain(&new_chain, &old_chain, 0, false);
         }
         return true;
     }
 
-
-    pub fn wind_chain(&mut self, new_chain: &Vec<[u8;32]>, old_chain: &Vec<[u8;32]>, current_wind_index: usize, wind_failure: bool) -> bool {
-
+    pub fn wind_chain(
+        &mut self,
+        new_chain: &Vec<[u8; 32]>,
+        old_chain: &Vec<[u8; 32]>,
+        current_wind_index: usize,
+        wind_failure: bool,
+    ) -> bool {
         let block = &self.blocks[&new_chain[current_wind_index]];
 
         //
@@ -257,24 +256,23 @@ self.blockring.print_lc();
         let does_block_validate = block.validate();
 
         if does_block_validate {
-
             block.on_chain_reorganization(&mut self.utxoset, true);
-            self.blockring.on_chain_reorganization(block.get_id(), block.get_hash(), true);
+            self.blockring
+                .on_chain_reorganization(block.get_id(), block.get_hash(), true);
 
-            if current_wind_index == (new_chain.len()-1) {
-                if wind_failure { return false }
+            if current_wind_index == (new_chain.len() - 1) {
+                if wind_failure {
+                    return false;
+                }
                 return true;
             }
 
-            return self.wind_chain(new_chain, old_chain, current_wind_index+1, false);
-
+            return self.wind_chain(new_chain, old_chain, current_wind_index + 1, false);
         } else {
-
             //
             // tough luck, go back to the old chain
             //
             if current_wind_index == 0 {
-
                 //
                 // this is the first block we have tried to add
                 // and so we can just roll out the older chain
@@ -289,24 +287,33 @@ self.blockring.print_lc();
                 // true -> force -> we had issues, is failure
                 //
                 return self.wind_chain(old_chain, new_chain, 0, true);
-
             } else {
-
-                let mut chain_to_unwind : Vec<[u8;32]> = vec![];
+                let mut chain_to_unwind: Vec<[u8; 32]> = vec![];
                 for i in current_wind_index..new_chain.len() {
                     chain_to_unwind.push(new_chain[i].clone());
                 }
-                return self.unwind_chain(old_chain, &chain_to_unwind, chain_to_unwind.len()-1, true);
+                return self.unwind_chain(
+                    old_chain,
+                    &chain_to_unwind,
+                    chain_to_unwind.len() - 1,
+                    true,
+                );
             }
         }
     }
 
-    pub fn unwind_chain(&mut self, new_chain: &Vec<[u8;32]>, old_chain: &Vec<[u8;32]>, current_unwind_index: usize, wind_failure : bool) -> bool {
-
+    pub fn unwind_chain(
+        &mut self,
+        new_chain: &Vec<[u8; 32]>,
+        old_chain: &Vec<[u8; 32]>,
+        current_unwind_index: usize,
+        wind_failure: bool,
+    ) -> bool {
         let block = &self.blocks[&old_chain[current_unwind_index]];
 
         block.on_chain_reorganization(&mut self.utxoset, false);
-	self.blockring.on_chain_reorganization(block.get_id(), block.get_hash(), false);
+        self.blockring
+            .on_chain_reorganization(block.get_id(), block.get_hash(), false);
 
         if current_unwind_index == 0 {
             //
@@ -317,11 +324,7 @@ self.blockring.print_lc();
             //
             // continue unwinding
             //
-            return self.unwind_chain(new_chain, old_chain, current_unwind_index-1, wind_failure);
+            return self.unwind_chain(new_chain, old_chain, current_unwind_index - 1, wind_failure);
         }
-
     }
-
-
-
 }

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -31,6 +31,11 @@ impl RingItem {
         }
     }
 
+    pub fn contains_block_hash(&mut self, hash : SaitoHash) -> bool {
+        if self.block_hashes.iter().any(|&i| i == hash) { return true; }
+	return false;
+    }
+
     pub fn add_block(&mut self, block_id : u64, hash : SaitoHash) {
 	self.block_hashes.push(hash);
 	self.block_ids.push(block_id);
@@ -114,7 +119,12 @@ impl BlockRing {
         }
     }
 
-    pub fn add_block(&mut self, block: Block) {
+    pub fn contains_block_hash_at_block_id(&mut self, block_id : u64 , block_hash : SaitoHash) -> bool {
+	let insert_pos = block_id % RING_BUFFER_LENGTH;
+	return self.block_ring[(insert_pos as usize)].contains_block_hash(block_hash);	
+    }
+
+    pub fn add_block(&mut self, block: &Block) {
 	let insert_pos = block.get_id() % RING_BUFFER_LENGTH;
 	self.block_ring[(insert_pos as usize)].add_block(block.get_id(), block.get_hash());	
     }
@@ -142,6 +152,16 @@ impl BlockRing {
 	    return self.block_ring[self.block_ring_lc_pos].block_hashes[lc_pos];
 	} else {
 	    return [0; 32];
+	}
+    }
+
+    pub fn get_longest_chain_block_id(&self) -> u64 {
+	if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX { return 0; }
+	let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
+	if lc_pos != usize::MAX {
+	    return self.block_ring[self.block_ring_lc_pos].block_ids[lc_pos];
+	} else {
+	    return 0;
 	}
     }
 

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -1,28 +1,25 @@
 use crate::block::Block;
-use crate::crypto::{SaitoHash};
+use crate::crypto::SaitoHash;
 
 const EPOCH_LENGTH: u64 = 21000;
 const RING_BUFFER_LENGTH: u64 = 2 * EPOCH_LENGTH;
-
-
 
 //
 // This is an index with shorthand information on the block_ids and hashes of the blocks
 // in the longest-chain.
 //
-// The BlockRing is a fixed size Vector which can be made contiguous and theoretically 
+// The BlockRing is a fixed size Vector which can be made contiguous and theoretically
 // made available for fast-access through a slice with the same lifetime as the vector
 // itself.
 //
 #[derive(Debug)]
 pub struct RingItem {
-    lc_pos: usize,	// which idx in the vectors below points to the longest-chain block
+    lc_pos: usize, // which idx in the vectors below points to the longest-chain block
     block_hashes: Vec<SaitoHash>,
     block_ids: Vec<u64>,
 }
 
 impl RingItem {
-
     pub fn new() -> Self {
         Self {
             lc_pos: usize::MAX,
@@ -31,64 +28,61 @@ impl RingItem {
         }
     }
 
-    pub fn contains_block_hash(&mut self, hash : SaitoHash) -> bool {
-        if self.block_hashes.iter().any(|&i| i == hash) { return true; }
-	return false;
+    pub fn contains_block_hash(&mut self, hash: SaitoHash) -> bool {
+        if self.block_hashes.iter().any(|&i| i == hash) {
+            return true;
+        }
+        return false;
     }
 
-    pub fn add_block(&mut self, block_id : u64, hash : SaitoHash) {
-	self.block_hashes.push(hash);
-	self.block_ids.push(block_id);
+    pub fn add_block(&mut self, block_id: u64, hash: SaitoHash) {
+        self.block_hashes.push(hash);
+        self.block_ids.push(block_id);
     }
 
-    pub fn on_chain_reorganization(&mut self, hash : SaitoHash, lc : bool) {
+    pub fn on_chain_reorganization(&mut self, hash: SaitoHash, lc: bool) {
+        if !lc {
+            self.lc_pos = usize::MAX;
+        } else {
+            //
+            // update new longest-chain
+            //
+            for i in 0..self.block_hashes.len() {
+                if self.block_hashes[i] == hash {
+                    self.lc_pos = i;
+                }
+            }
 
-	if !lc {
-	    self.lc_pos = usize::MAX;
-	} else {
+            //
+            // remove any old indices
+            //
+            let current_block_id = self.block_ids[self.lc_pos];
 
-	    //
-	    // update new longest-chain
-	    //
-	    for i in 0..self.block_hashes.len() {
-	        if self.block_hashes[i] == hash { 
-	            self.lc_pos = i;
-	        }
-	    }
+            let mut new_block_hashes: Vec<SaitoHash> = vec![];
+            let mut new_block_ids: Vec<u64> = vec![];
 
-	    //
-	    // remove any old indices
-	    //
-	    let current_block_id = self.block_ids[self.lc_pos];
+            for i in 0..self.block_ids.len() {
+                if self.block_ids[i] < current_block_id {
+                    self.lc_pos = i;
+                } else {
+                    new_block_hashes.push(self.block_hashes[i]);
+                    new_block_ids.push(self.block_ids[i]);
+                }
+            }
 
-	    let mut new_block_hashes: Vec<SaitoHash> = vec![];
-	    let mut new_block_ids: Vec<u64> = vec![];
-
-	    for i in 0..self.block_ids.len() {
-	        if self.block_ids[i] < current_block_id { 
-	            self.lc_pos = i;
-	        } else {
-		    new_block_hashes.push(self.block_hashes[i]);
-		    new_block_ids.push(self.block_ids[i]);
-		}
-	    }
-
-	    self.block_hashes = new_block_hashes;
-	    self.block_ids = new_block_ids;
-
-	}
+            self.block_hashes = new_block_hashes;
+            self.block_ids = new_block_ids;
+        }
     }
 }
 
-
 //
-// TODO - we can optimize this.  
+// TODO - we can optimize this.
 //
 // The Blockchain Index is a self-contained data structure
 //
 #[derive(Debug)]
 pub struct BlockRing {
-
     //
     // each ring_item is a point on our blockchain
     //
@@ -98,20 +92,18 @@ pub struct BlockRing {
     block_ring: Vec<RingItem>,
     /// a ring of blocks, index is not the block_id.
     block_ring_lc_pos: usize,
-
 }
 
-
 impl BlockRing {
-
     /// Create new `BlockRing`
     pub fn new() -> Self {
-
-	//
-	// initialize the block-ring
-	//
+        //
+        // initialize the block-ring
+        //
         let mut init_block_ring: Vec<RingItem> = vec![];
-        for _i in 0..EPOCH_LENGTH { init_block_ring.push(RingItem::new()); }
+        for _i in 0..EPOCH_LENGTH {
+            init_block_ring.push(RingItem::new());
+        }
 
         BlockRing {
             block_ring: init_block_ring,
@@ -119,65 +111,79 @@ impl BlockRing {
         }
     }
 
-
-pub fn print_lc(&self) {
-    for i in 0..EPOCH_LENGTH { 
-        if self.block_ring[(i as usize)].block_hashes.len() > 0 {
-	    println!("Block {:?}: {:?}", i, self.get_longest_chain_block_hash_by_block_id(i));
-	}
+    pub fn print_lc(&self) {
+        for i in 0..EPOCH_LENGTH {
+            if self.block_ring[(i as usize)].block_hashes.len() > 0 {
+                println!(
+                    "Block {:?}: {:?}",
+                    i,
+                    self.get_longest_chain_block_hash_by_block_id(i)
+                );
+            }
+        }
     }
-}
 
-
-    pub fn contains_block_hash_at_block_id(&mut self, block_id : u64 , block_hash : SaitoHash) -> bool {
-	let insert_pos = block_id % RING_BUFFER_LENGTH;
-	return self.block_ring[(insert_pos as usize)].contains_block_hash(block_hash);	
+    pub fn contains_block_hash_at_block_id(
+        &mut self,
+        block_id: u64,
+        block_hash: SaitoHash,
+    ) -> bool {
+        let insert_pos = block_id % RING_BUFFER_LENGTH;
+        return self.block_ring[(insert_pos as usize)].contains_block_hash(block_hash);
     }
 
     pub fn add_block(&mut self, block: &Block) {
-	let insert_pos = block.get_id() % RING_BUFFER_LENGTH;
-	self.block_ring[(insert_pos as usize)].add_block(block.get_id(), block.get_hash());	
+        let insert_pos = block.get_id() % RING_BUFFER_LENGTH;
+        self.block_ring[(insert_pos as usize)].add_block(block.get_id(), block.get_hash());
     }
 
-    pub fn on_chain_reorganization(&mut self, block_id: u64 , hash: SaitoHash, lc : bool) {
-	let insert_pos = block_id % RING_BUFFER_LENGTH;
-	self.block_ring[(insert_pos as usize)].on_chain_reorganization(hash, lc);
-        if lc { self.block_ring_lc_pos = insert_pos as usize; }
+    pub fn on_chain_reorganization(&mut self, block_id: u64, hash: SaitoHash, lc: bool) {
+        let insert_pos = block_id % RING_BUFFER_LENGTH;
+        self.block_ring[(insert_pos as usize)].on_chain_reorganization(hash, lc);
+        if lc {
+            self.block_ring_lc_pos = insert_pos as usize;
+        }
     }
 
     pub fn get_longest_chain_block_hash_by_block_id(&self, id: u64) -> SaitoHash {
-	let insert_pos = id % RING_BUFFER_LENGTH;
-	let lc_pos = self.block_ring[(insert_pos as usize)].lc_pos;
-	if lc_pos != usize::MAX {
-	    return self.block_ring[(insert_pos as usize)].block_hashes[lc_pos];
-	} else {
-	    return [0; 32];
-	}
+        let insert_pos = id % RING_BUFFER_LENGTH;
+        let lc_pos = self.block_ring[(insert_pos as usize)].lc_pos;
+        if lc_pos != usize::MAX {
+            return self.block_ring[(insert_pos as usize)].block_hashes[lc_pos];
+        } else {
+            return [0; 32];
+        }
     }
 
     pub fn get_longest_chain_block_hash(&self) -> SaitoHash {
-	if self.block_ring_lc_pos == usize::MAX { return [0; 32]; }
-	if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX { return [0; 32]; }
-	let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
-	if lc_pos != usize::MAX {
-	    return self.block_ring[self.block_ring_lc_pos].block_hashes[lc_pos];
-	} else {
-	    return [0; 32];
-	}
+        if self.block_ring_lc_pos == usize::MAX {
+            return [0; 32];
+        }
+        if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX {
+            return [0; 32];
+        }
+        let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
+        if lc_pos != usize::MAX {
+            return self.block_ring[self.block_ring_lc_pos].block_hashes[lc_pos];
+        } else {
+            return [0; 32];
+        }
     }
 
     pub fn get_longest_chain_block_id(&self) -> u64 {
-	if self.block_ring_lc_pos == usize::MAX { return 0; }
-	if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX { return 0; }
-	let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
-	if lc_pos != usize::MAX {
-	    return self.block_ring[self.block_ring_lc_pos].block_ids[lc_pos];
-	} else {
-	    return 0;
-	}
+        if self.block_ring_lc_pos == usize::MAX {
+            return 0;
+        }
+        if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX {
+            return 0;
+        }
+        let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
+        if lc_pos != usize::MAX {
+            return self.block_ring[self.block_ring_lc_pos].block_ids[lc_pos];
+        } else {
+            return 0;
+        }
     }
-
-
 }
 
 #[cfg(test)]
@@ -188,10 +194,4 @@ mod test {
     fn longest_chain_queue_test() {
         assert_eq!(1, 1);
     }
-
 }
-
-
-
-
-

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -119,6 +119,16 @@ impl BlockRing {
         }
     }
 
+
+pub fn print_lc(&self) {
+    for i in 0..EPOCH_LENGTH { 
+        if self.block_ring[(i as usize)].block_hashes.len() > 0 {
+	    println!("Block {:?}: {:?}", i, self.get_longest_chain_block_hash_by_block_id(i));
+	}
+    }
+}
+
+
     pub fn contains_block_hash_at_block_id(&mut self, block_id : u64 , block_hash : SaitoHash) -> bool {
 	let insert_pos = block_id % RING_BUFFER_LENGTH;
 	return self.block_ring[(insert_pos as usize)].contains_block_hash(block_hash);	
@@ -146,6 +156,7 @@ impl BlockRing {
     }
 
     pub fn get_longest_chain_block_hash(&self) -> SaitoHash {
+	if self.block_ring_lc_pos == usize::MAX { return [0; 32]; }
 	if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX { return [0; 32]; }
 	let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
 	if lc_pos != usize::MAX {
@@ -156,6 +167,7 @@ impl BlockRing {
     }
 
     pub fn get_longest_chain_block_id(&self) -> u64 {
+	if self.block_ring_lc_pos == usize::MAX { return 0; }
 	if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX { return 0; }
 	let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
 	if lc_pos != usize::MAX {

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -1,0 +1,165 @@
+use crate::block::Block;
+use crate::crypto::{SaitoHash};
+
+const EPOCH_LENGTH: u64 = 21000;
+const RING_BUFFER_LENGTH: u64 = 2 * EPOCH_LENGTH;
+
+
+
+//
+// This is an index with shorthand information on the block_ids and hashes of the blocks
+// in the longest-chain.
+//
+// The BlockRing is a fixed size Vector which can be made contiguous and theoretically 
+// made available for fast-access through a slice with the same lifetime as the vector
+// itself.
+//
+#[derive(Debug)]
+pub struct RingItem {
+    lc_pos: usize,	// which idx in the vectors below points to the longest-chain block
+    block_hashes: Vec<SaitoHash>,
+    block_ids: Vec<u64>,
+}
+
+impl RingItem {
+
+    pub fn new() -> Self {
+        Self {
+            lc_pos: usize::MAX,
+            block_hashes: vec![],
+            block_ids: vec![],
+        }
+    }
+
+    pub fn add_block(&mut self, block_id : u64, hash : SaitoHash) {
+	self.block_hashes.push(hash);
+	self.block_ids.push(block_id);
+    }
+
+    pub fn on_chain_reorganization(&mut self, hash : SaitoHash, lc : bool) {
+
+	if !lc {
+	    self.lc_pos = usize::MAX;
+	} else {
+
+	    //
+	    // update new longest-chain
+	    //
+	    for i in 0..self.block_hashes.len() {
+	        if self.block_hashes[i] == hash { 
+	            self.lc_pos = i;
+	        }
+	    }
+
+	    //
+	    // remove any old indices
+	    //
+	    let current_block_id = self.block_ids[self.lc_pos];
+
+	    let mut new_block_hashes: Vec<SaitoHash> = vec![];
+	    let mut new_block_ids: Vec<u64> = vec![];
+
+	    for i in 0..self.block_ids.len() {
+	        if self.block_ids[i] < current_block_id { 
+	            self.lc_pos = i;
+	        } else {
+		    new_block_hashes.push(self.block_hashes[i]);
+		    new_block_ids.push(self.block_ids[i]);
+		}
+	    }
+
+	    self.block_hashes = new_block_hashes;
+	    self.block_ids = new_block_ids;
+
+	}
+    }
+}
+
+
+//
+// TODO - we can optimize this.  
+//
+// The Blockchain Index is a self-contained data structure
+//
+#[derive(Debug)]
+pub struct BlockRing {
+
+    //
+    // each ring_item is a point on our blockchain
+    //
+    // include Slice-VecDeque and have a slice that points to
+    // contiguous entries for rapid lookups, inserts and updates?
+    //
+    block_ring: Vec<RingItem>,
+    /// a ring of blocks, index is not the block_id.
+    block_ring_lc_pos: usize,
+
+}
+
+
+impl BlockRing {
+
+    /// Create new `BlockRing`
+    pub fn new() -> Self {
+
+	//
+	// initialize the block-ring
+	//
+        let mut init_block_ring: Vec<RingItem> = vec![];
+        for _i in 0..EPOCH_LENGTH { init_block_ring.push(RingItem::new()); }
+
+        BlockRing {
+            block_ring: init_block_ring,
+            block_ring_lc_pos: usize::MAX,
+        }
+    }
+
+    pub fn add_block(&mut self, block: Block) {
+	let insert_pos = block.get_id() % RING_BUFFER_LENGTH;
+	self.block_ring[(insert_pos as usize)].add_block(block.get_id(), block.get_hash());	
+    }
+
+    pub fn on_chain_reorganization(&mut self, block_id: u64 , hash: SaitoHash, lc : bool) {
+	let insert_pos = block_id % RING_BUFFER_LENGTH;
+	self.block_ring[(insert_pos as usize)].on_chain_reorganization(hash, lc);
+        if lc { self.block_ring_lc_pos = insert_pos as usize; }
+    }
+
+    pub fn get_longest_chain_block_hash_by_block_id(&self, id: u64) -> SaitoHash {
+	let insert_pos = id % RING_BUFFER_LENGTH;
+	let lc_pos = self.block_ring[(insert_pos as usize)].lc_pos;
+	if lc_pos != usize::MAX {
+	    return self.block_ring[(insert_pos as usize)].block_hashes[lc_pos];
+	} else {
+	    return [0; 32];
+	}
+    }
+
+    pub fn get_longest_chain_block_hash(&self) -> SaitoHash {
+	if self.block_ring[self.block_ring_lc_pos].lc_pos == usize::MAX { return [0; 32]; }
+	let lc_pos = self.block_ring[self.block_ring_lc_pos].lc_pos;
+	if lc_pos != usize::MAX {
+	    return self.block_ring[self.block_ring_lc_pos].block_hashes[lc_pos];
+	} else {
+	    return [0; 32];
+	}
+    }
+
+
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn longest_chain_queue_test() {
+        assert_eq!(1, 1);
+    }
+
+}
+
+
+
+
+

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -23,7 +23,6 @@ pub enum SaitoMessage {
 
 /// Run the Saito consensus runtime
 pub async fn run(shutdown: impl Future) -> crate::Result<()> {
-
     //
     // handle shutdown messages using broadcast channel
     //

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -10,9 +10,9 @@ pub type SaitoSignature = [u8; 64];
 
 pub const PARALLEL_HASH_BYTE_THRESHOLD: usize = 128_000;
 
-
 pub fn generate_keys() -> (SaitoPublicKey, SaitoPrivateKey) {
-    let (mut secret_key, mut public_key) = SECP256K1.generate_keypair(&mut secp256k1::rand::thread_rng());
+    let (mut secret_key, mut public_key) =
+        SECP256K1.generate_keypair(&mut secp256k1::rand::thread_rng());
     while public_key.serialize().to_base58().len() != 44 {
         // sometimes secp256k1 address is too big to store in 44 base-58 digits
         let keypair_tuple = SECP256K1.generate_keypair(&mut secp256k1::rand::thread_rng());
@@ -20,8 +20,10 @@ pub fn generate_keys() -> (SaitoPublicKey, SaitoPrivateKey) {
         public_key = keypair_tuple.1;
     }
     let mut secret_bytes = [0u8; 32];
-    for i in 0..32 { secret_bytes[i] = secret_key[i]; }
-    return (public_key.serialize() , secret_bytes);
+    for i in 0..32 {
+        secret_bytes[i] = secret_key[i];
+    }
+    return (public_key.serialize(), secret_bytes);
 }
 
 pub fn hash(data: &Vec<u8>) -> SaitoHash {
@@ -50,4 +52,3 @@ pub fn verify(msg: &[u8], sig: SaitoSignature, publickey: SaitoPublicKey) -> boo
     let s = Signature::from_compact(&sig).unwrap();
     SECP256K1.verify(&m, &s, &p).is_ok()
 }
-

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -3,6 +3,7 @@ use blake3::{join::RayonJoin, Hasher};
 pub use secp256k1::{Message, PublicKey, SecretKey, Signature, SECP256K1};
 
 pub type SaitoHash = [u8; 32];
+pub type SaitoUTXOSetKey = Vec<u8>;
 pub type SaitoPublicKey = [u8; 33];
 pub type SaitoPrivateKey = [u8; 32]; // 256-bit key
 pub type SaitoSignature = [u8; 64];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ dev@saito.tech
 pub mod big_array;
 pub mod block;
 pub mod blockchain;
+pub mod blockring;
 pub mod consensus;
 pub mod crypto;
 pub mod mempool;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -54,12 +54,14 @@ impl Mempool {
         &mut self,
         blockchain_lock: Arc<RwLock<Blockchain>>,
     ) -> Block {
+
         let blockchain = blockchain_lock.read().await;
         let previous_block_id = blockchain.get_latest_block_id();
         let previous_block_hash = blockchain.get_latest_block_hash();
 
         let mut block = Block::default();
-        block.set_id(previous_block_id);
+
+        block.set_id(previous_block_id+1);
         block.set_previous_block_hash(previous_block_hash);
 
 	let wallet = self.wallet_lock.read().await;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,6 +1,11 @@
 use crate::{
-    block::Block, blockchain::Blockchain, consensus::SaitoMessage, crypto::{hash, verify}, slip::Slip,
-    transaction::Transaction, wallet::Wallet,
+    block::Block,
+    blockchain::Blockchain,
+    consensus::SaitoMessage,
+    crypto::{hash, verify},
+    slip::Slip,
+    transaction::Transaction,
+    wallet::Wallet,
 };
 use std::{collections::VecDeque, sync::Arc, thread::sleep, time::Duration};
 use tokio::sync::{broadcast, mpsc, RwLock};
@@ -50,24 +55,19 @@ impl Mempool {
         }
     }
 
-    pub async fn generate_block(
-        &mut self,
-        blockchain_lock: Arc<RwLock<Blockchain>>,
-    ) -> Block {
-
+    pub async fn generate_block(&mut self, blockchain_lock: Arc<RwLock<Blockchain>>) -> Block {
         let blockchain = blockchain_lock.read().await;
         let previous_block_id = blockchain.get_latest_block_id();
         let previous_block_hash = blockchain.get_latest_block_hash();
 
         let mut block = Block::default();
 
-        block.set_id(previous_block_id+1);
+        block.set_id(previous_block_id + 1);
         block.set_previous_block_hash(previous_block_hash);
 
-	let wallet = self.wallet_lock.read().await;
+        let wallet = self.wallet_lock.read().await;
 
         for _i in 0..1000 {
-
             let mut transaction = Transaction::default();
 
             transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());
@@ -96,7 +96,6 @@ impl Mempool {
             if !v {
                 println!("Transaction does not Validate: {:?}", v);
             }
-
         }
 
         let block_merkle_root = block.generate_merkle_root();

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -115,25 +115,23 @@ impl Slip {
         vbytes
     }
 
-
-    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, _lc : bool , slip_value : u64) {
-
+    pub fn on_chain_reorganization(
+        &self,
+        utxoset: &mut AHashMap<SaitoUTXOSetKey, u64>,
+        _lc: bool,
+        slip_value: u64,
+    ) {
         let slip_key = self.get_utxoset_key();
         utxoset.entry(slip_key).or_insert(slip_value);
-
-
     }
 
     pub fn get_utxoset_key(&self) -> SaitoUTXOSetKey {
-
-        let mut res:Vec<u8> = vec![];
+        let mut res: Vec<u8> = vec![];
         res.extend(&self.get_publickey());
         res.extend(&self.get_uuid());
         res.extend(&self.get_amount().to_be_bytes());
         return res;
-
     }
-
 
     pub fn validate(&self) -> bool {
         return true;

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -116,7 +116,7 @@ impl Slip {
     }
 
 
-    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, longest_chain : bool , slip_value : u64) {
+    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, _lc : bool , slip_value : u64) {
 
         let slip_key = self.get_utxoset_key();
         utxoset.entry(slip_key).or_insert(slip_value);

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -1,6 +1,8 @@
 use crate::big_array::BigArray;
-use crate::crypto::{SaitoPublicKey, SaitoSignature};
+use crate::crypto::{SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey};
 use serde::{Deserialize, Serialize};
+
+use ahash::AHashMap;
 
 /// SlipType is a human-readable indicator of the slip-type, such
 /// as in a normal transaction, a VIP-transaction, a rebroadcast
@@ -112,6 +114,26 @@ impl Slip {
         vbytes.extend(&(self.core.slip_type as u32).to_be_bytes());
         vbytes
     }
+
+
+    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, longest_chain : bool , slip_value : u64) {
+
+        let slip_key = self.get_utxoset_key();
+        utxoset.entry(slip_key).or_insert(slip_value);
+
+
+    }
+
+    pub fn get_utxoset_key(&self) -> SaitoUTXOSetKey {
+
+        let mut res:Vec<u8> = vec![];
+        res.extend(&self.get_publickey());
+        res.extend(&self.get_uuid());
+        res.extend(&self.get_amount().to_be_bytes());
+        return res;
+
+    }
+
 
     pub fn validate(&self) -> bool {
         return true;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,14 @@
-use crate::{big_array::BigArray, crypto::{hash, sign, verify, SaitoHash, SaitoPrivateKey, SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey}, slip::Slip, time::create_timestamp};
-use serde::{Deserialize, Serialize};
+use crate::{
+    big_array::BigArray,
+    crypto::{
+        hash, sign, verify, SaitoHash, SaitoPrivateKey, SaitoPublicKey, SaitoSignature,
+        SaitoUTXOSetKey,
+    },
+    slip::Slip,
+    time::create_timestamp,
+};
 use ahash::AHashMap;
+use serde::{Deserialize, Serialize};
 
 /// TransactionType is a human-readable indicator of the type of
 /// transaction such as a normal user-initiated transaction, a
@@ -157,9 +165,12 @@ impl Transaction {
         vbytes
     }
 
-
-    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, longest_chain : bool, block_id : u64) {
-
+    pub fn on_chain_reorganization(
+        &self,
+        utxoset: &mut AHashMap<SaitoUTXOSetKey, u64>,
+        longest_chain: bool,
+        block_id: u64,
+    ) {
         if longest_chain {
             for input in self.get_inputs() {
                 input.on_chain_reorganization(utxoset, longest_chain, block_id);
@@ -174,11 +185,8 @@ impl Transaction {
             for output in self.get_outputs() {
                 output.on_chain_reorganization(utxoset, longest_chain, 0);
             }
-
-
         }
     }
-
 
     pub fn validate(&self) -> bool {
         //

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,5 +1,6 @@
-use crate::{big_array::BigArray, crypto::{hash, sign, verify, SaitoHash, SaitoPrivateKey, SaitoPublicKey, SaitoSignature}, slip::Slip, time::create_timestamp};
+use crate::{big_array::BigArray, crypto::{hash, sign, verify, SaitoHash, SaitoPrivateKey, SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey}, slip::Slip, time::create_timestamp};
 use serde::{Deserialize, Serialize};
+use ahash::AHashMap;
 
 /// TransactionType is a human-readable indicator of the type of
 /// transaction such as a normal user-initiated transaction, a
@@ -155,6 +156,29 @@ impl Transaction {
 
         vbytes
     }
+
+
+    pub fn on_chain_reorganization(&self, utxoset : &mut AHashMap<SaitoUTXOSetKey, u64>, longest_chain : bool, block_id : u64) {
+
+        if longest_chain {
+            for input in self.get_inputs() {
+                input.on_chain_reorganization(utxoset, longest_chain, block_id);
+            }
+            for output in self.get_outputs() {
+                output.on_chain_reorganization(utxoset, longest_chain, 1);
+            }
+        } else {
+            for input in self.get_inputs() {
+                input.on_chain_reorganization(utxoset, longest_chain, 1);
+            }
+            for output in self.get_outputs() {
+                output.on_chain_reorganization(utxoset, longest_chain, 0);
+            }
+
+
+        }
+    }
+
 
     pub fn validate(&self) -> bool {
         //

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,4 +1,4 @@
-use crate::crypto::{sign, generate_keys, SaitoPrivateKey, SaitoPublicKey, SaitoSignature};
+use crate::crypto::{generate_keys, sign, SaitoPrivateKey, SaitoPublicKey, SaitoSignature};
 
 /// The `Wallet` manages the public and private keypair of the node and holds the
 /// slips that are used to form transactions on the network.
@@ -9,10 +9,9 @@ pub struct Wallet {
 }
 
 impl Wallet {
-
     #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Self {
-	let (publickey , privatekey) = generate_keys();
+        let (publickey, privatekey) = generate_keys();
         Wallet {
             publickey: publickey,
             privatekey: privatekey,
@@ -39,6 +38,4 @@ mod tests {
     fn wallet_new_test() {
         assert_eq!(true, true);
     }
-
-
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -39,4 +39,6 @@ mod tests {
     fn wallet_new_test() {
         assert_eq!(true, true);
     }
+
+
 }


### PR DESCRIPTION
Will be continuing to work on this, but sharing a push so that people can see this code in advance. This brings the essentials of wind / unwind chain into Rust. It updates the Blockchain file so that blocks are processed and added in a chain. And it preserves but modifies the fast-access VecDeque that Clay has suggested as a BlockRing.

Blockring.rs is an abstract class and the exact data structures inside should be discussed and can be upgraded without affecting the logic of how we process blocks. The need for the elements in the Blockring to have variable-size components means we can no longer store this on the stack in contiguous memory, so I am wondering if the best approach might be using a SliceDeqVeque -- https://docs.rs/slice-deque/0.3.0/slice_deque/. We could also use a Vector and simply maintain a slice of entries in the struct that remains valid over the lifetime of the program and use them for fast access to elements in the middle if needed. Suggestions welcome.

In terms of functionality, the major change with this implementation is that the BlockRing maintains information on multiple blocks and chains as opposed to simply the hashes that form the longest-chain. It updates its own variable indicating which is the longest-chain when the chain is reorganized (on_chain_reorganization).This view into how many blocks exist at arbitrary block_ids is needed for ATR deletion and will be useful for congestion policy. It also avoids the need for the tree of blocks stored in the hashmap to contain information on their children. The addition of parentless blocks is also now possible. The data structure is more flexible.

Blockchain has gained AHashMap named "utxoset" that is serving as the UTXOSet. We have continued the tradition of using add_block() and on_chain_reorganization() as our two essential functions for adding blocks and updating state when the chain is updated. Prevalidation is possible and can permit us to skip wind / unwind chain step, although we now skip ALL interactions with the UTXOset if the block is not identified as a suitable candidate for the longest-chain.

We should be able to move forward fleshing out the validation steps and adding unit tests.

