### PR TITLE
Sequential refactor blockring and blockchain add block

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -227,9 +227,14 @@ impl Block {
         return true;
     }
 
-    pub fn validate(&self) -> bool {
-        let _transactions_valid = &self.transactions.par_iter().all(|tx| tx.validate());
+    pub fn validate(&mut self) -> bool {
 
+	//
+	// we validate transactions before generating the merkle_root
+	// and calculating the block hashes, as we need to be able to 
+	// generate the tx_sigs
+	//
+        let _transactions_valid = &self.transactions.par_iter_mut().all(|tx| tx.validate());
         return true;
     }
 }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -248,7 +248,10 @@ impl Blockchain {
         current_wind_index: usize,
         wind_failure: bool,
     ) -> bool {
-        let block = &self.blocks[&new_chain[current_wind_index]];
+
+        let block = self.blocks.get_mut(&new_chain[current_wind_index]).unwrap();
+
+//        let block = &mut self.blocks[&new_chain[current_wind_index]];
 
         //
         // validate the block

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -56,6 +56,7 @@ impl Mempool {
     }
 
     pub async fn generate_block(&mut self, blockchain_lock: Arc<RwLock<Blockchain>>) -> Block {
+
         let blockchain = blockchain_lock.read().await;
         let previous_block_id = blockchain.get_latest_block_id();
         let previous_block_hash = blockchain.get_latest_block_hash();
@@ -67,7 +68,10 @@ impl Mempool {
 
         let wallet = self.wallet_lock.read().await;
 
-        for _i in 0..1000 {
+        for _i in 0..10000 {
+
+println!("creating tx {:?}", _i);
+
             let mut transaction = Transaction::default();
 
             transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -188,21 +188,32 @@ impl Transaction {
         }
     }
 
-    pub fn validate(&self) -> bool {
+    pub fn validate(&mut self) -> bool {
+
         //
         // validate sigs
         //
-        let msg: SaitoHash = hash(&self.serialize_for_signature());
+        let hash_for_signature: SaitoHash = hash(&self.serialize_for_signature());
         let sig: SaitoSignature = self.get_signature();
         let mut publickey: SaitoPublicKey = [0; 33];
         if self.core.inputs.len() > 0 {
             publickey = self.core.inputs[0].get_publickey();
         }
 
-        if !verify(&msg, sig, publickey) {
+        if !verify(&hash_for_signature, sig, publickey) {
             println!("message verifies not");
             return false;
         }
+
+	//
+	// if we have received the transaction over the network we
+	// may not have the tx's signature_for_hash actually saved
+	// locally, which we will need in order to generate the 
+	// merkle_root and the slip UUIDs. so save here:
+	//
+	self.set_hash_for_signature(hash_for_signature);
+	
+
 
         //
         // UTXO validate inputs


### PR DESCRIPTION
This updates block validate() to mutable so that transactions can have their hash_for_signature saved in the process of their being generated -- for use avoiding double-work in merkle_root generation / validation.