### PR TITLE
Feature: add slips to wallet and collect in add_block_sucess

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -1,12 +1,10 @@
 use crate::{
-    crypto::{
-        hash, MerkleTree, SaitoHash, SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey, SHA256,
-    },
+    blockchain::UtxoSet,
+    crypto::{hash, MerkleTree, SaitoHash, SaitoPublicKey, SaitoSignature, SHA256},
     slip::SLIP_SIZE,
     time::create_timestamp,
     transaction::{Transaction, TRANSACTION_SIZE},
 };
-use ahash::AHashMap;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
@@ -332,11 +330,7 @@ impl Block {
             .expect("Faiiled to unwrao merkle root")
     }
 
-    pub fn on_chain_reorganization(
-        &self,
-        utxoset: &mut AHashMap<SaitoUTXOSetKey, u64>,
-        longest_chain: bool,
-    ) -> bool {
+    pub fn on_chain_reorganization(&self, utxoset: &mut UtxoSet, longest_chain: bool) -> bool {
         for tx in &self.transactions {
             tx.on_chain_reorganization(utxoset, longest_chain, self.get_id());
         }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -70,7 +70,7 @@ impl Consensus {
         // messages, as well as setters.
         //
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-        let blockchain_lock = Arc::new(RwLock::new(Blockchain::new()));
+        let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let storage = Storage::new();
         storage.load_blocks_from_disk(blockchain_lock.clone()).await;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -148,7 +148,7 @@ pub async fn run(
                         let mut mempool = mempool_lock.write().await;
                         let mut blockchain = blockchain_lock.write().await;
                         while let Some(block) = mempool.blocks.pop_front() {
-                            blockchain.add_block(block);
+                            blockchain.add_block(block).await;
                         }
                     },
                 }

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -1,9 +1,9 @@
-use crate::crypto::{SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey};
-use serde::{Deserialize, Serialize};
-
-use ahash::AHashMap;
-
+use crate::{
+    blockchain::UtxoSet,
+    crypto::{SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey},
+};
 use enum_variant_count_derive::TryFromByte;
+use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
 /// The size of a serilized slip in bytes.
@@ -27,7 +27,7 @@ pub enum SlipType {
 /// should be handled through getters and setters in the block which
 /// surrounds it.
 #[serde_with::serde_as]
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Copy, Clone)]
 pub struct SlipCore {
     #[serde_as(as = "[_; 33]")]
     publickey: SaitoPublicKey,
@@ -62,7 +62,7 @@ impl Default for SlipCore {
     }
 }
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Copy)]
 pub struct Slip {
     core: SlipCore,
 }
@@ -121,12 +121,7 @@ impl Slip {
         vbytes
     }
 
-    pub fn on_chain_reorganization(
-        &self,
-        utxoset: &mut AHashMap<SaitoUTXOSetKey, u64>,
-        _lc: bool,
-        slip_value: u64,
-    ) {
+    pub fn on_chain_reorganization(&self, utxoset: &mut UtxoSet, _lc: bool, slip_value: u64) {
         let slip_key = self.get_utxoset_key();
         utxoset.entry(slip_key).or_insert(slip_value);
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -55,7 +55,7 @@ impl Storage {
                 println!("get lock...");
                 let mut blockchain = blockchain_lock.write().await;
                 println!("adding...");
-                blockchain.add_block(block);
+                blockchain.add_block(block).await;
                 println!("Loaded block {} of {}", pos, paths.len() - 1);
             }
         }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,4 +1,10 @@
-use crate::crypto::{generate_keys, sign, SaitoPrivateKey, SaitoPublicKey, SaitoSignature};
+use crate::{
+    crypto::{
+        generate_keys, sign, SaitoPrivateKey, SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey,
+    },
+    slip::Slip,
+};
+use std::collections::HashMap;
 
 /// The `Wallet` manages the public and private keypair of the node and holds the
 /// slips that are used to form transactions on the network.
@@ -6,6 +12,7 @@ use crate::crypto::{generate_keys, sign, SaitoPrivateKey, SaitoPublicKey, SaitoS
 pub struct Wallet {
     publickey: SaitoPublicKey,
     privatekey: SaitoPrivateKey,
+    slips: HashMap<SaitoUTXOSetKey, Slip>,
 }
 
 impl Wallet {
@@ -15,6 +22,7 @@ impl Wallet {
         Wallet {
             publickey,
             privatekey,
+            slips: HashMap::new(),
         }
     }
 
@@ -28,6 +36,14 @@ impl Wallet {
 
     pub fn sign(&self, message_bytes: &[u8]) -> SaitoSignature {
         sign(message_bytes, self.privatekey)
+    }
+
+    pub fn add_slip(&mut self, slip: Slip) {
+        self.slips.insert(slip.get_utxoset_key(), slip);
+    }
+
+    pub fn remove_slip(&mut self, slip: &Slip) {
+        self.slips.remove(&slip.get_utxoset_key());
     }
 }
 


### PR DESCRIPTION
This still needs to be extended to `on_chain_reorganization`, but due to `wallet_lock` being behind an `async` `RwLock` makes the implementation complicated. Either `un/wind_chain` will have to be changed to manage `async` recursive functions, or the lock will have to be changed.