### PR TITLE
parallel merkle root generation

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -25,6 +25,7 @@ impl Blockchain {
 
     pub fn add_block(&mut self, block: Block) {
         println!(" ... add_block start: {:?}", create_timestamp());
+        println!(" ... txs in block: {:?}", block.transactions.len());
 
         //
         // start by extracting some variables that we will use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub mod blockring;
 pub mod consensus;
 pub mod crypto;
 pub mod mempool;
+pub mod merkle;
 pub mod network;
 pub mod slip;
 pub mod storage;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -67,7 +67,7 @@ impl Mempool {
 
         let wallet = self.wallet_lock.read().await;
 
-        for _i in 0..10 {
+        for _i in 0..10000 {
             println!("creating tx {:?}", _i);
 
             let mut transaction = Transaction::default();
@@ -75,12 +75,12 @@ impl Mempool {
             transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());
 
             let mut input1 = Slip::default();
-            input1.set_publickey([1; 33]);
+            input1.set_publickey(wallet.get_publickey());
             input1.set_amount(1000000);
             input1.set_uuid([1; 64]);
 
             let mut output1 = Slip::default();
-            output1.set_publickey([1; 33]);
+            output1.set_publickey(wallet.get_publickey());
             output1.set_amount(1000000);
             output1.set_uuid([1; 64]);
 
@@ -98,6 +98,8 @@ impl Mempool {
             if !v {
                 println!("Transaction does not Validate: {:?}", v);
             }
+
+            block.add_transaction(transaction);
         }
 
         let block_merkle_root = block.generate_merkle_root();
@@ -126,7 +128,7 @@ pub async fn run(
                 .send(MempoolMessage::GenerateBlock)
                 .await
                 .expect("error: GenerateBlock message failed to send");
-            sleep(Duration::from_millis(5000));
+            sleep(Duration::from_millis(20000));
         }
     });
 

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,0 +1,37 @@
+use crate::crypto::{hash, SaitoHash};
+use rayon::prelude::*;
+
+//
+// MerkleTreeLayer is a short implementation that uses the default
+// Saito hashing algorithm. It is also written to take advantage of
+// rayon parallelization.
+//
+#[derive(PartialEq, Debug, Clone)]
+pub struct MerkleTreeLayer {
+    left: SaitoHash,
+    right: SaitoHash,
+    hash: SaitoHash,
+    level: u8,
+}
+impl MerkleTreeLayer {
+    pub fn new(left: SaitoHash, right: SaitoHash, level: u8) -> MerkleTreeLayer {
+        MerkleTreeLayer {
+            left: left,
+            right: right,
+            level: level,
+            hash: [0; 32],
+        }
+    }
+
+    pub fn hash(&mut self) -> bool {
+        let mut vbytes: Vec<u8> = vec![];
+        vbytes.extend(&self.left);
+        vbytes.extend(&self.right);
+        self.hash = hash(&vbytes);
+        true
+    }
+
+    pub fn get_hash(&self) -> SaitoHash {
+        self.hash
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -325,14 +325,18 @@ impl Transaction {
         for output in &self.core.outputs {
             nolan_out += output.get_amount();
         }
-        if nolan_in < 0 {
-            println!("ERROR 672939: negative payment in transaction from slip");
-            return false;
-        }
-        if nolan_out < 0 {
-            println!("ERROR 672940: negative payment in transaction to slip");
-            return false;
-        }
+
+        //
+        // Rust Types prevent these variables being < 0
+        //
+        //        if nolan_in < 0 {
+        //            println!("ERROR 672939: negative payment in transaction from slip");
+        //            return false;
+        //        }
+        //        if nolan_out < 0 {
+        //            println!("ERROR 672940: negative payment in transaction to slip");
+        //            return false;
+        //        }
         if nolan_out > nolan_in {
             println!("ERROR 672941: transaction spends more than it has available");
             return false;


### PR DESCRIPTION
This branch manually generates MerkleRoot instead of relying on an external library. Among the advantages:

* this uses the default Saito hashing algorithm instead of using Sha256
* rayon used for parallel generation of hashes, etc.

Timestamps below calculated on blocks with 10,000 txs each of which has a 1024 byte message field.

OLD
 ... start merkle: 1625035550570
 ... stop merkle:  1625035550714

NEW
 ... start merkle: 1625035717373
 ... stop merkle:  1625035717389


