### PR TITLE
chore: cleanup warnings

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -195,8 +195,7 @@ impl Blockchain {
         // manually checked that the entry exists in order to pull
         // this trick. we did this check before validating.
         //
-	let mut block = self.blocks.get_mut(&block_hash).unwrap().set_lc(true);
-        let storage = Storage::new();
+	    let storage = Storage::new();
         storage.write_block_to_disk(self.blocks.get(&block_hash).unwrap());
     }
     pub fn add_block_failure(&mut self) {}
@@ -269,12 +268,10 @@ impl Blockchain {
 	//
 	if wind_failure == true && new_chain.len() == 0 { return false; }
 
-        let block = self.blocks.get_mut(&new_chain[current_wind_index]).unwrap();
-
         {
 	    // yes, there is a warning here, but we need the mutable borrow to set the 
 	    // tx.hash_for_signature information inside AFAICT
-            let mut block = self.blocks.get_mut(&new_chain[current_wind_index]).unwrap();
+            let block = self.blocks.get_mut(&new_chain[current_wind_index]).unwrap();
 
             //
             // validate the block

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -157,13 +157,12 @@ impl BlockRing {
 	    // only adjust longest_chain if this is it
 	    //
 	    if self.block_ring_lc_pos == insert_pos as usize {
-	        let mut previous_block_idx = self.block_ring_lc_pos-1;
+	        let previous_block_idx = self.block_ring_lc_pos-1;
 
 	        // reset to lc_pos to unknown
 	        self.block_ring_lc_pos = usize::MAX;
 
 	        // but try to find it
-	        if previous_block_idx < 0 { previous_block_idx = RING_BUFFER_LENGTH as usize - 1; }
 	        let previous_block_idx_lc_pos = self.block_ring[previous_block_idx as usize].lc_pos;
 	        if previous_block_idx_lc_pos != usize::MAX {
 	            if self.block_ring[previous_block_idx].block_ids.len() > previous_block_idx_lc_pos {
@@ -220,7 +219,7 @@ impl BlockRing {
 
 #[cfg(test)]
 mod test {
-    use crate::test_utilities::mocks::{make_mock_block, make_mock_invalid_block};
+    use crate::test_utilities::mocks::{make_mock_block};
 
     use super::*;
     #[test]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -289,12 +289,12 @@ impl Transaction {
         //
         let hash_for_signature: SaitoHash = self.get_hash_for_signature();
         let sig: SaitoSignature = self.get_signature();
-        let mut publickey: SaitoPublicKey = [0; 33];
-        if !self.core.inputs.is_empty() {
-            publickey = self.core.inputs[0].get_publickey();
-        } else {
+        
+
+        if self.core.inputs.is_empty() {
             panic!("transaction must have at least 1 input");
         }
+        let publickey: SaitoPublicKey = self.core.inputs[0].get_publickey();
 
         if !verify(&hash_for_signature, sig, publickey) {
             println!("message verifies not");


### PR DESCRIPTION
It's important that we keep the code warning-free. Warning are useful when developing because I use them to catch my own mistakes. This doesn't work well if there are other warnings already present.