### PR TITLE
feat: Block.generate_block() is a simple function to generate valid b…

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -164,20 +164,17 @@ impl Blockchain {
                 }
             }
         } else {
-
-	    //
-	    // we can hit this point in the code if we have a block without a parent, 
-	    // in which case we want to process it without unwind/wind chain, or if
-	    // we are adding our very first block, in which case we do want to process
-	    // it.
-	    //
-	    // TODO more elegant handling of the first block and other non-longest-chain
-	    // blocks.
-	    //
+            //
+            // we can hit this point in the code if we have a block without a parent,
+            // in which case we want to process it without unwind/wind chain, or if
+            // we are adding our very first block, in which case we do want to process
+            // it.
+            //
+            // TODO more elegant handling of the first block and other non-longest-chain
+            // blocks.
+            //
             println!("We have added a block without a parent block... ");
-
         }
-
 
         //
         // at this point we should have a shared ancestor or not
@@ -203,19 +200,18 @@ impl Blockchain {
         if am_i_the_longest_chain {
             let does_new_chain_validate = self.validate(new_chain, old_chain);
             if does_new_chain_validate {
-
                 self.add_block_success(block_hash).await;
 
-        	//
-        	// TODO
-        	//
-        	// mutable update is hell -- we can do this but have to have
-        	// manually checked that the entry exists in order to pull
-        	// this trick. we did this check before validating.
-        	//
-        	{
-        	    self.blocks.get_mut(&block_hash).unwrap().set_lc(true);
-        	}
+                //
+                // TODO
+                //
+                // mutable update is hell -- we can do this but have to have
+                // manually checked that the entry exists in order to pull
+                // this trick. we did this check before validating.
+                //
+                {
+                    self.blocks.get_mut(&block_hash).unwrap().set_lc(true);
+                }
 
                 if !self.broadcast_channel_sender.is_none() {
                     self.broadcast_channel_sender
@@ -260,10 +256,9 @@ impl Blockchain {
     }
 
     pub async fn add_block_success(&mut self, block_hash: SaitoHash) {
-
-	//
-	// save to disk
-	//
+        //
+        // save to disk
+        //
         let storage = Storage::new();
         storage.write_block_to_disk(self.blocks.get(&block_hash).unwrap());
 
@@ -278,7 +273,6 @@ impl Blockchain {
             wallet.add_block(&block);
             println!(" ... finsh wallet: {}", create_timestamp());
         }
-
     }
     pub async fn add_block_failure(&mut self) {}
 
@@ -339,7 +333,6 @@ impl Blockchain {
         new_chain: &Vec<[u8; 32]>,
         old_chain: &Vec<[u8; 32]>,
     ) -> bool {
-
         if old_chain.len() > new_chain.len() {
             println!("ERROR 1");
             return false;
@@ -575,9 +568,9 @@ pub async fn run(
 #[cfg(test)]
 
 mod tests {
-    use crate::test_utilities::mocks::make_mock_block;
-    use crate::miner::Miner;
     use super::*;
+    use crate::miner::Miner;
+    use crate::test_utilities::mocks::make_mock_block;
 
     #[tokio::test]
     async fn add_block_test_1() {
@@ -678,7 +671,6 @@ mod tests {
         prev_block = mock_block_1.clone();
         // extend the fork to match the height of LC, the latest block id/hash shouldn't change yet...
         for _n in 0..5 {
-
             let next_block = make_mock_block(
                 prev_block.get_timestamp(),
                 prev_block.get_burnfee(),
@@ -686,8 +678,9 @@ mod tests {
                 prev_block.get_id() + 1,
             );
 
-	    let golden_ticket_transaction = miner.mine_on_block_until_golden_ticket_found(prev_block);
-	    next_block.add_transaction(golden_ticket_transaction);
+            let golden_ticket_transaction =
+                miner.mine_on_block_until_golden_ticket_found(prev_block);
+            next_block.add_transaction(golden_ticket_transaction);
 
             blockchain.add_block(next_block.clone()).await;
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,16 +1,15 @@
 use crate::{
-    block::{Block, DataToValidate},
+    block::Block,
     blockchain::Blockchain,
     burnfee::BurnFee,
     consensus::SaitoMessage,
-    crypto::{hash, verify, SaitoHash},
     golden_ticket::GoldenTicket,
     slip::Slip,
     time::create_timestamp,
     transaction::Transaction,
     wallet::Wallet,
 };
-use std::{collections::VecDeque, mem, sync::Arc, thread::sleep, time::Duration};
+use std::{collections::VecDeque, sync::Arc, thread::sleep, time::Duration};
 use tokio::sync::{broadcast, mpsc, RwLock};
 
 #[derive(Clone, Debug)]
@@ -102,13 +101,8 @@ impl Mempool {
 
         // convert into transaction
         let mut wallet = self.wallet_lock.write().await;
+	// hash_for_signature generated in creating txs
         let transaction = wallet.create_golden_ticket_transaction(golden_ticket).await;
-
-        //
-        // create hash_for_signature to avoid failure generating merkle_root
-        // - TODO - we can remove this
-        //let hash_for_signature: SaitoHash = hash(&transaction.serialize_for_signature());
-        //transaction.set_hash_for_signature(hash_for_signature);
 
         if self
             .transactions
@@ -177,178 +171,17 @@ impl Mempool {
         return false;
     }
 
-    pub async fn generate_block_from_mempool(
+
+    pub async fn generate_block(
         &mut self,
         blockchain_lock: Arc<RwLock<Blockchain>>,
     ) -> Block {
-
-        let blockchain = blockchain_lock.read().await;
-        let previous_block_id = blockchain.get_latest_block_id();
-        let previous_block_hash = blockchain.get_latest_block_hash();
-
-        let mut block = Block::new();
-
-        let previous_block_burnfee = blockchain.get_latest_block_burnfee();
-        let previous_block_timestamp = blockchain.get_latest_block_timestamp();
-        let previous_block_difficulty = blockchain.get_latest_block_difficulty();
-
-        let current_timestamp = create_timestamp();
-        let current_burnfee: u64 =
-            BurnFee::return_burnfee_for_block_produced_at_current_timestamp_in_nolan(
-                previous_block_burnfee,
-                current_timestamp,
-                previous_block_timestamp,
-            );
-
-        block.set_id(previous_block_id + 1);
-        block.set_previous_block_hash(previous_block_hash);
-        block.set_burnfee(current_burnfee);
-        block.set_timestamp(current_timestamp);
-        block.set_difficulty(previous_block_difficulty);
-
-        //println!("pre-swap: {} vs {}", block.transactions.len(), self.transactions.len());
-        mem::swap(&mut block.transactions, &mut self.transactions);
-        //println!("post-swap: {} vs {}", block.transactions.len(), self.transactions.len());
-
-	//
-	// TODO - not ideal that we have to loop through the block
-	// can't we put GT in a specific location?
-	//
-	// check for golden ticket 
-	//
-        for transaction in &self.transactions {
-	    if transaction.is_golden_ticket() {
-		block.set_has_golden_ticket(true);
-		break;
-	    }
-	}
-
-        //
-        // create
-        //
-        let cv: DataToValidate = block.generate_data_to_validate(&blockchain);
-
-	//
-	// fee transactions and golden tickets
-        //
-        // set hash_for_signature for fee_tx as we cannot mutably fetch it
-        // during merkle_root generation as those functions require parallel
-        // processing in block validation. So some extra code here.
-        //
-        if !cv.fee_transaction.is_none() {
-
-            //
-            // fee-transaction must still pass validation rules
-            //
-            let mut fee_tx = cv.fee_transaction.unwrap();
-            let wallet = self.wallet_lock.write().await;
-
-            for input in fee_tx.get_mut_inputs() {
-                input.set_publickey(wallet.get_publickey());
-            }
-            let hash_for_signature: SaitoHash = hash(&fee_tx.serialize_for_signature());
-            fee_tx.set_hash_for_signature(hash_for_signature);
-
-            //
-            // sign the transaction and finalize it
-            //
-            fee_tx.sign(wallet.get_privatekey());
-
-            block.add_transaction(fee_tx);
-	    block.set_has_fee_transaction(true);
-
-        }
-
-
-	//
-	// validate difficulty
-	//
-        if cv.expected_difficulty != 0 {
-	    block.set_difficulty(cv.expected_difficulty);
-        }
-
-        let block_merkle_root = block.generate_merkle_root();
-        block.set_merkle_root(block_merkle_root);
-        let block_hash = block.generate_hash();
-        block.set_hash(block_hash);
-
-        let wallet = self.wallet_lock.read().await;
-	block.sign(wallet.get_publickey(), wallet.get_privatekey());
-
+	let blockchain = blockchain_lock.read().await;
+	let previous_block_hash = blockchain.get_latest_block_hash();
+	let block = Block::generate_block(&mut self.transactions, previous_block_hash, self.wallet_lock.clone(), blockchain_lock.clone()).await;
         block
     }
 
-    pub async fn generate_block(&mut self, blockchain_lock: Arc<RwLock<Blockchain>>) -> Block {
-        let blockchain = blockchain_lock.read().await;
-        let previous_block_id = blockchain.get_latest_block_id();
-        let previous_block_hash = blockchain.get_latest_block_hash();
-
-        let mut block = Block::new();
-
-        let previous_block_burnfee = blockchain.get_latest_block_burnfee();
-        let previous_block_timestamp = blockchain.get_latest_block_timestamp();
-        let current_timestamp = create_timestamp();
-
-        //println!("BUILDING FROM BF: {}", previous_block_burnfee);
-        //println!("BUILDING FROM TS: {}", previous_block_timestamp);
-        //println!("BUILDING FROM ID: {}", previous_block_id);
-
-        let new_burnfee: u64 =
-            BurnFee::return_burnfee_for_block_produced_at_current_timestamp_in_nolan(
-                previous_block_burnfee,
-                current_timestamp,
-                previous_block_timestamp,
-            );
-
-        block.set_id(previous_block_id + 1);
-        block.set_previous_block_hash(previous_block_hash);
-        block.set_burnfee(new_burnfee);
-        block.set_timestamp(current_timestamp);
-
-        let wallet = self.wallet_lock.read().await;
-
-        for _i in 0..10 {
-            //            println!("creating tx {:?}", _i);
-
-            let mut transaction = Transaction::new();
-
-            transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());
-
-            let mut input1 = Slip::new();
-            input1.set_publickey(wallet.get_publickey());
-            input1.set_amount(1000000);
-            input1.set_uuid([1; 32]);
-
-            let mut output1 = Slip::new();
-            output1.set_publickey(wallet.get_publickey());
-            output1.set_amount(1000000);
-            output1.set_uuid([1; 32]);
-
-            transaction.add_input(input1);
-            transaction.add_output(output1);
-
-            // sign ...
-            transaction.sign(wallet.get_privatekey());
-            let tx_sig = transaction.get_signature();
-
-            // ... and verify
-            let vbytes = transaction.serialize_for_signature();
-            let hash = hash(&vbytes);
-            let v = verify(&hash, tx_sig, wallet.get_publickey());
-            if !v {
-                println!("Transaction does not Validate: {:?}", v);
-            }
-
-            block.add_transaction(transaction);
-        }
-
-        let block_merkle_root = block.generate_merkle_root();
-        block.set_merkle_root(block_merkle_root);
-        let block_hash = block.generate_hash();
-        block.set_hash(block_hash);
-
-        block
-    }
 }
 
 // This function is called on initialization to setup the sending
@@ -396,8 +229,7 @@ pub async fn run(
                         let mut mempool = mempool_lock.write().await;
                         let can_bundle = mempool.can_bundle_block(blockchain_lock.clone()).await;
                         if can_bundle {
-                            //let block = mempool.generate_block(blockchain_lock.clone()).await;
-                            let block = mempool.generate_block_from_mempool(blockchain_lock.clone()).await;
+                            let block = mempool.generate_block(blockchain_lock.clone()).await;
                             if AddBlockResult::Accepted == mempool.add_block(block) {
                                 mempool_channel_sender.send(MempoolMessage::ProcessBlocks).await.expect("Failed to send ProcessBlocks message");
                             }
@@ -418,56 +250,58 @@ pub async fn run(
                     MempoolMessage::GenerateTransaction => {
 
                         let mut mempool = mempool_lock.write().await;
-                let wallet_publickey;
-                let wallet_privatekey;
+        	        let wallet_publickey;
+                        let wallet_privatekey;
 
-            {
-                let wallet = mempool.wallet_lock.read().await;
-                wallet_publickey = wallet.get_publickey();
-                wallet_privatekey = wallet.get_privatekey();
-            }
+            		{
+            		    let wallet = mempool.wallet_lock.read().await;
+            		    wallet_publickey = wallet.get_publickey();
+            		    wallet_privatekey = wallet.get_privatekey();
+            		}
 
-            let current_txs_in_mempool = mempool.transactions.len();
+            		let current_txs_in_mempool: u8 = mempool.transactions.len() as u8;
 
-                for _i in 0..10 {
+            		for _i in 0..10 {
 
-                        println!("creating tx {:?}", (_i+current_txs_in_mempool+1));
+            		    //println!("creating tx {:?}", (_i+current_txs_in_mempool+1));
+          		    let mut transaction = Transaction::new();
 
-                        let mut transaction = Transaction::new();
+		            transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());
 
-                    transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());
+			    //
+			    // as fake transactions, we set the UUID arbitrarily
+			    //
+		            let mut input1 = Slip::new();
+		            input1.set_publickey(wallet_publickey);
+		            input1.set_amount(1000000);
+		            input1.set_uuid([current_txs_in_mempool+(_i as u8); 32]);
 
-                    let mut input1 = Slip::new();
-                    input1.set_publickey(wallet_publickey);
-                           input1.set_amount(1000000);
-                    input1.set_uuid([1; 32]);
+		            let mut output1 = Slip::new();
+		            output1.set_publickey(wallet_publickey);
+		            output1.set_amount(1000000);
+		            output1.set_uuid([0; 32]);
 
-                    let mut output1 = Slip::new();
-                    output1.set_publickey(wallet_publickey);
-                    output1.set_amount(1000000);
-                    output1.set_uuid([1; 32]);
+		            transaction.add_input(input1);
+		            transaction.add_output(output1);
 
-                    transaction.add_input(input1);
-                       transaction.add_output(output1);
+		            // sign ...
+		            transaction.sign(wallet_privatekey);
+		            mempool.add_transaction(transaction);
 
-                    // sign ...
-                    transaction.sign(wallet_privatekey);
-                        mempool.add_transaction(transaction);
+		        }
+	           },
 
-                }
-                    },
-
-                    // ProcessBlocks will add blocks FIFO from the queue into blockchain
-                    MempoolMessage::ProcessBlocks => {
-                        let mut mempool = mempool_lock.write().await;
-                    mempool.currently_processing_block = true;
-                        let mut blockchain = blockchain_lock.write().await;
-                        while let Some(block) = mempool.blocks.pop_front() {
-                            blockchain.add_block(block).await;
-                        }
-                    mempool.currently_processing_block = false;
-                    },
-                }
+                   // ProcessBlocks will add blocks FIFO from the queue into blockchain
+                   MempoolMessage::ProcessBlocks => {
+                       let mut mempool = mempool_lock.write().await;
+                       mempool.currently_processing_block = true;
+                       let mut blockchain = blockchain_lock.write().await;
+                       while let Some(block) = mempool.blocks.pop_front() {
+                           blockchain.add_block(block).await;
+                       }
+                       mempool.currently_processing_block = false;
+                   },
+               }
             }
 
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,12 +1,6 @@
 use crate::{
-    block::Block,
-    blockchain::Blockchain,
-    burnfee::BurnFee,
-    consensus::SaitoMessage,
-    golden_ticket::GoldenTicket,
-    slip::Slip,
-    time::create_timestamp,
-    transaction::Transaction,
+    block::Block, blockchain::Blockchain, burnfee::BurnFee, consensus::SaitoMessage,
+    golden_ticket::GoldenTicket, slip::Slip, time::create_timestamp, transaction::Transaction,
     wallet::Wallet,
 };
 use std::{collections::VecDeque, sync::Arc, thread::sleep, time::Duration};
@@ -98,10 +92,9 @@ impl Mempool {
     // the right block. this pushes the golden ticket indiscriminately into the
     // transaction array -- we can do a better job.
     pub async fn add_golden_ticket(&mut self, golden_ticket: GoldenTicket) -> AddTransactionResult {
-
         // convert into transaction
         let mut wallet = self.wallet_lock.write().await;
-	// hash_for_signature generated in creating txs
+        // hash_for_signature generated in creating txs
         let transaction = wallet.create_golden_ticket_transaction(golden_ticket).await;
 
         if self
@@ -171,17 +164,18 @@ impl Mempool {
         return false;
     }
 
-
-    pub async fn generate_block(
-        &mut self,
-        blockchain_lock: Arc<RwLock<Blockchain>>,
-    ) -> Block {
-	let blockchain = blockchain_lock.read().await;
-	let previous_block_hash = blockchain.get_latest_block_hash();
-	let block = Block::generate_block(&mut self.transactions, previous_block_hash, self.wallet_lock.clone(), blockchain_lock.clone()).await;
+    pub async fn generate_block(&mut self, blockchain_lock: Arc<RwLock<Blockchain>>) -> Block {
+        let blockchain = blockchain_lock.read().await;
+        let previous_block_hash = blockchain.get_latest_block_hash();
+        let block = Block::generate_block(
+            &mut self.transactions,
+            previous_block_hash,
+            self.wallet_lock.clone(),
+            blockchain_lock.clone(),
+        )
+        .await;
         block
     }
-
 }
 
 // This function is called on initialization to setup the sending
@@ -250,46 +244,46 @@ pub async fn run(
                     MempoolMessage::GenerateTransaction => {
 
                         let mut mempool = mempool_lock.write().await;
-        	        let wallet_publickey;
+                    let wallet_publickey;
                         let wallet_privatekey;
 
-            		{
-            		    let wallet = mempool.wallet_lock.read().await;
-            		    wallet_publickey = wallet.get_publickey();
-            		    wallet_privatekey = wallet.get_privatekey();
-            		}
+                    {
+                        let wallet = mempool.wallet_lock.read().await;
+                        wallet_publickey = wallet.get_publickey();
+                        wallet_privatekey = wallet.get_privatekey();
+                    }
 
-            		let current_txs_in_mempool: u8 = mempool.transactions.len() as u8;
+                    let current_txs_in_mempool: u8 = mempool.transactions.len() as u8;
 
-            		for _i in 0..10 {
+                    for _i in 0..10 {
 
-            		    //println!("creating tx {:?}", (_i+current_txs_in_mempool+1));
-          		    let mut transaction = Transaction::new();
+                        //println!("creating tx {:?}", (_i+current_txs_in_mempool+1));
+                      let mut transaction = Transaction::new();
 
-		            transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());
+                    transaction.set_message((0..1024).map(|_| rand::random::<u8>()).collect());
 
-			    //
-			    // as fake transactions, we set the UUID arbitrarily
-			    //
-		            let mut input1 = Slip::new();
-		            input1.set_publickey(wallet_publickey);
-		            input1.set_amount(1000000);
-		            input1.set_uuid([current_txs_in_mempool+(_i as u8); 32]);
+                //
+                // as fake transactions, we set the UUID arbitrarily
+                //
+                    let mut input1 = Slip::new();
+                    input1.set_publickey(wallet_publickey);
+                    input1.set_amount(1000000);
+                    input1.set_uuid([current_txs_in_mempool+(_i as u8); 32]);
 
-		            let mut output1 = Slip::new();
-		            output1.set_publickey(wallet_publickey);
-		            output1.set_amount(1000000);
-		            output1.set_uuid([0; 32]);
+                    let mut output1 = Slip::new();
+                    output1.set_publickey(wallet_publickey);
+                    output1.set_amount(1000000);
+                    output1.set_uuid([0; 32]);
 
-		            transaction.add_input(input1);
-		            transaction.add_output(output1);
+                    transaction.add_input(input1);
+                    transaction.add_output(output1);
 
-		            // sign ...
-		            transaction.sign(wallet_privatekey);
-		            mempool.add_transaction(transaction);
+                    // sign ...
+                    transaction.sign(wallet_privatekey);
+                    mempool.add_transaction(transaction);
 
-		        }
-	           },
+                }
+               },
 
                    // ProcessBlocks will add blocks FIFO from the queue into blockchain
                    MempoolMessage::ProcessBlocks => {

--- a/src/miner.rs
+++ b/src/miner.rs
@@ -70,24 +70,21 @@ impl Miner {
         }
     }
 
-
-    pub async fn mine_on_block_until_golden_ticket_found(&mut self, block : Block) -> GoldenTicket {
-
+    pub async fn mine_on_block_until_golden_ticket_found(&mut self, block: Block) -> GoldenTicket {
         let wallet = self.wallet_lock.read().await;
-	let publickey = wallet.get_publickey();
+        let publickey = wallet.get_publickey();
         let mut random_bytes = hash(&generate_random_bytes(32));
         let mut solution = GoldenTicket::generate_solution(random_bytes, publickey);
 
-	while !GoldenTicket::is_valid_solution(block.get_hash(), solution, block.get_difficulty()) {
+        while !GoldenTicket::is_valid_solution(block.get_hash(), solution, block.get_difficulty()) {
             random_bytes = hash(&generate_random_bytes(32));
             solution = GoldenTicket::generate_solution(random_bytes, publickey);
-	}
+        }
 
         let vote = 0;
         let golden_ticket = GoldenTicket::new(vote, self.target, random_bytes, publickey);
-   
-        golden_ticket
 
+        golden_ticket
     }
 
     pub fn set_is_active(&mut self, is_active: bool) {

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -24,7 +24,6 @@ pub enum SlipType {
     Other, // need more than one value for TryFromBytes
 }
 
-
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct Slip {
@@ -37,21 +36,17 @@ pub struct Slip {
 }
 
 impl Slip {
-
     pub fn new() -> Self {
         Self {
-	    publickey: [0; 33],
-	    uuid: [0; 32],
-	    amount: 0,
-	    slip_ordinal: 0,
-	    slip_type: SlipType::Normal
-	}
+            publickey: [0; 33],
+            uuid: [0; 32],
+            amount: 0,
+            slip_ordinal: 0,
+            slip_type: SlipType::Normal,
+        }
     }
 
-    pub fn validate(
-	&self,
-        _utxoset: &AHashMap<SaitoUTXOSetKey, u64>,
-    ) -> bool {
+    pub fn validate(&self, _utxoset: &AHashMap<SaitoUTXOSetKey, u64>) -> bool {
         true
     }
 
@@ -111,7 +106,6 @@ impl Slip {
         self.slip_type = slip_type;
     }
 
-
     //
     // Serialization
     //
@@ -142,14 +136,13 @@ impl Slip {
         let slip_type: SlipType = SlipType::try_from(bytes[SLIP_SIZE - 1]).unwrap();
         let mut slip = Slip::new();
 
-	slip.set_publickey(publickey);
-	slip.set_uuid(uuid);
-	slip.set_amount(amount);
-	slip.set_slip_ordinal(slip_ordinal);
-	slip.set_slip_type(slip_type);
-	
-	slip
+        slip.set_publickey(publickey);
+        slip.set_uuid(uuid);
+        slip.set_amount(amount);
+        slip.set_slip_ordinal(slip_ordinal);
+        slip.set_slip_type(slip_type);
 
+        slip
     }
     pub fn serialize_for_net(&self) -> Vec<u8> {
         let mut vbytes: Vec<u8> = vec![];
@@ -161,7 +154,6 @@ impl Slip {
         vbytes
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -48,7 +48,10 @@ impl Slip {
 	}
     }
 
-    pub fn validate(&self) -> bool {
+    pub fn validate(
+	&self,
+        _utxoset: &AHashMap<SaitoUTXOSetKey, u64>,
+    ) -> bool {
         true
     }
 
@@ -60,7 +63,7 @@ impl Slip {
     ) {
         if self.get_amount() > 0 {
             let slip_key = self.get_utxoset_key();
-            println!("inserting slip into shashmap: {:?}", slip_key);
+            //println!("inserting slip into shashmap: {:?}", slip_key);
             utxoset.entry(slip_key).or_insert(slip_value);
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -50,7 +50,6 @@ impl Storage {
                 let mut encoded = Vec::<u8>::new();
                 f.read_to_end(&mut encoded).unwrap();
                 let mut block = Block::deserialize_for_net(encoded);
-                println!("loading block with hash: {:?}", block.get_hash());
 
                 //
                 // the hash needs calculation separately after loading

--- a/src/test.txt
+++ b/src/test.txt
@@ -1,0 +1,100 @@
+
+    pub async fn generate_block(
+        &mut self,
+	transactions: &mut Vec<Transaction>,
+	previous_block: &Block,
+        blockchain_lock: Arc<RwLock<Blockchain>>,
+    ) -> Block {
+
+        let blockchain = blockchain_lock.read().await;
+
+        let previous_block_id = previous_block.get_id();
+        let previous_block_hash = previous_block.get_hash();
+        let previous_block_burnfee = previous_block.get_burnfee();
+        let previous_block_timestamp = previous_block.get_timestamp();
+        let previous_block_difficulty = blockchain.get_difficulty();
+
+        let mut block = Block::new();
+
+        let current_timestamp = create_timestamp();
+        let current_burnfee: u64 =
+            BurnFee::return_burnfee_for_block_produced_at_current_timestamp_in_nolan(
+                previous_block_burnfee,
+                current_timestamp,
+                previous_block_timestamp,
+            );
+
+        block.set_id(previous_block_id + 1);
+        block.set_previous_block_hash(previous_block_hash);
+        block.set_burnfee(current_burnfee);
+        block.set_timestamp(current_timestamp);
+        block.set_difficulty(previous_block_difficulty);
+
+        mem::swap(&mut block.transactions, &mut transactions);
+
+	//
+	// TODO - not ideal that we have to loop through the block.
+	// perhaps we can put GT in a specific location.
+	//
+        for transaction in &block.transactions {
+	    if transaction.is_golden_ticket() {
+		block.set_has_golden_ticket(true);
+		break;
+	    }
+	}
+
+        //
+        // create
+        //
+        let cv: DataToValidate = block.generate_data_to_validate(&blockchain);
+
+	//
+	// fee transactions and golden tickets
+        //
+        // set hash_for_signature for fee_tx as we cannot mutably fetch it
+        // during merkle_root generation as those functions require parallel
+        // processing in block validation. So some extra code here.
+        //
+        if !cv.fee_transaction.is_none() {
+
+            //
+            // fee-transaction must still pass validation rules
+            //
+            let mut fee_tx = cv.fee_transaction.unwrap();
+            let wallet = self.wallet_lock.write().await;
+
+            for input in fee_tx.get_mut_inputs() {
+                input.set_publickey(wallet.get_publickey());
+            }
+            let hash_for_signature: SaitoHash = hash(&fee_tx.serialize_for_signature());
+            fee_tx.set_hash_for_signature(hash_for_signature);
+
+            //
+            // sign the transaction and finalize it
+            //
+            fee_tx.sign(wallet.get_privatekey());
+
+            block.add_transaction(fee_tx);
+	    block.set_has_fee_transaction(true);
+
+        }
+
+
+	//
+	// validate difficulty
+	//
+        if cv.expected_difficulty != 0 {
+	    block.set_difficulty(cv.expected_difficulty);
+        }
+
+        let block_merkle_root = block.generate_merkle_root();
+        block.set_merkle_root(block_merkle_root);
+        let block_hash = block.generate_hash();
+        block.set_hash(block_hash);
+
+        let wallet = self.wallet_lock.read().await;
+	block.sign(wallet.get_publickey(), wallet.get_privatekey());
+
+        block
+    }
+

--- a/src/test_utilities/mocks.rs
+++ b/src/test_utilities/mocks.rs
@@ -1,8 +1,8 @@
-use crate::block::{Block};
+use crate::block::Block;
 use crate::burnfee::BurnFee;
 use crate::crypto::SaitoHash;
 use crate::slip::{Slip, SlipType};
-use crate::transaction::{Transaction};
+use crate::transaction::Transaction;
 use crate::wallet::Wallet;
 
 pub fn make_mock_block(
@@ -25,7 +25,7 @@ pub fn make_mock_block(
     mock_input.set_amount(1);
     mock_input.set_slip_ordinal(0);
     mock_input.set_slip_type(SlipType::Normal);
-   
+
     let mut mock_output = Slip::new();
     mock_output.set_publickey(wallet.get_publickey());
     mock_output.set_uuid([0; 32]);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -8,10 +8,10 @@ use crate::{
     slip::{Slip, SLIP_SIZE},
 };
 use ahash::AHashMap;
+use bigint::uint::U256;
 use enum_variant_count_derive::TryFromByte;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
-use bigint::uint::U256;
 
 pub const TRANSACTION_SIZE: usize = 85;
 
@@ -30,7 +30,6 @@ pub enum TransactionType {
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct Transaction {
-
     // the bulk of the consensus transaction data
     timestamp: u64,
     inputs: Vec<Slip>,
@@ -135,8 +134,7 @@ impl Transaction {
         self.signature
     }
 
-    pub fn get_winning_routing_node(&self, random_hash : SaitoHash) -> SaitoPublicKey {
-
+    pub fn get_winning_routing_node(&self, random_hash: SaitoHash) -> SaitoPublicKey {
         //
         // find winning router
         //
@@ -145,11 +143,10 @@ impl Transaction {
         let z = U256::from_big_endian(&y.to_be_bytes());
         let (_winning_routing_node_random, _bolres) = x.overflowing_rem(z);
 
-	//
-	// TODO - process routing path, return winner
-	//
+        //
+        // TODO - process routing path, return winner
+        //
         return self.inputs[0].get_publickey();
-
     }
 
     pub fn set_timestamp(&mut self, timestamp: u64) {
@@ -160,11 +157,11 @@ impl Transaction {
         self.transaction_type = transaction_type;
     }
 
-    pub fn set_inputs(&mut self, inputs : Vec<Slip>) {
+    pub fn set_inputs(&mut self, inputs: Vec<Slip>) {
         self.inputs = inputs;
     }
 
-    pub fn set_outputs(&mut self, outputs : Vec<Slip>) {
+    pub fn set_outputs(&mut self, outputs: Vec<Slip>) {
         self.outputs = outputs;
     }
 
@@ -251,13 +248,13 @@ impl Transaction {
             .try_into()
             .unwrap();
         let mut transaction = Transaction::new();
-	transaction.set_timestamp(timestamp);
-	transaction.set_inputs(inputs);
-	transaction.set_outputs(outputs);
-	transaction.set_message(message);
-	transaction.set_transaction_type(transaction_type);
-	transaction.set_signature(signature);
-	transaction
+        transaction.set_timestamp(timestamp);
+        transaction.set_inputs(inputs);
+        transaction.set_outputs(outputs);
+        transaction.set_message(message);
+        transaction.set_transaction_type(transaction_type);
+        transaction.set_signature(signature);
+        transaction
     }
 
     /// Serialize a Transaction for transport or disk.
@@ -287,7 +284,6 @@ impl Transaction {
         vbytes.extend(&self.message);
         vbytes
     }
-
 
     /// Runs when the chain is re-organized
     pub fn on_chain_reorganization(
@@ -336,11 +332,10 @@ impl Transaction {
             nolan_in += input.get_amount();
         }
         for output in &mut self.outputs {
-
             nolan_out += output.get_amount();
 
-	    // and set the UUID needed for insertion to shashmap
-	    output.set_uuid(hash_for_signature);
+            // and set the UUID needed for insertion to shashmap
+            output.set_uuid(hash_for_signature);
         }
         self.total_in = nolan_in;
         self.total_out = nolan_out;
@@ -358,8 +353,7 @@ impl Transaction {
 
         true
     }
-    pub fn validate(&self, utxoset : &AHashMap<SaitoUTXOSetKey, u64>) -> bool {
-
+    pub fn validate(&self, utxoset: &AHashMap<SaitoUTXOSetKey, u64>) -> bool {
         //
         // VALIDATE signature valid
         //
@@ -420,12 +414,11 @@ impl Transaction {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
-    use crate::slip::Slip;
-    use crate::time::{create_timestamp};
     use super::*;
+    use crate::slip::Slip;
+    use crate::time::create_timestamp;
 
     #[test]
     fn transaction_new_test() {
@@ -443,12 +436,12 @@ mod tests {
         let mock_input = Slip::new();
         let mock_output = Slip::new();
         let mut mock_tx = Transaction::new();
-	mock_tx.set_timestamp(create_timestamp());
-	mock_tx.add_input(mock_input);
-	mock_tx.add_output(mock_output);
-	mock_tx.set_message(vec![104, 101, 108, 108, 111]);
+        mock_tx.set_timestamp(create_timestamp());
+        mock_tx.add_input(mock_input);
+        mock_tx.add_output(mock_output);
+        mock_tx.set_message(vec![104, 101, 108, 108, 111]);
         mock_tx.set_transaction_type(TransactionType::Normal);
-	mock_tx.set_signature([1; 64]);
+        mock_tx.set_signature([1; 64]);
         let serialized_tx = mock_tx.serialize_for_net();
         let deserialized_tx = Transaction::deserialize_from_net(serialized_tx);
         assert_eq!(mock_tx, deserialized_tx);

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,6 +1,6 @@
 use crate::block::Block;
 use crate::crypto::{
-    hash, generate_keys, sign, SaitoHash, SaitoPrivateKey, SaitoPublicKey, SaitoSignature,
+    generate_keys, hash, sign, SaitoHash, SaitoPrivateKey, SaitoPublicKey, SaitoSignature,
     SaitoUTXOSetKey,
 };
 use crate::golden_ticket::GoldenTicket;


### PR DESCRIPTION
This provides a simplified function in the Block class that will generate a block that is valid according to consensus criteria.

    pub async fn generate_block(
        transactions: &mut Vec<Transaction>,
        previous_block_hash: SaitoHash,
        wallet_lock: Arc<RwLock<Wallet>>,
        blockchain_lock: Arc<RwLock<Blockchain>>,
    ) -> Block {

The intent is to simplify testing by ensuring that there is a single function producing valid blocks. It should also avoid the need for us to create blocks for testing purposes manually, and have to jerry-rig their values by hand. As long as the previous_block_hash is provided correctly the function will make sure that all block-level variables (difficulty, burnfee, treasury, etc.) are set as needed for the block to validate. This does not mean that the transactions will necessarily be valid or that the block will contain enough work, but it should simplify fork generation and testing.

The mempool has been adjusted to use this function when creating blocks instead of its own internal generate_blocks function. Part of the goal here is conceptual simplification in having the Block class manage everything needed for block creation. When asked to create blocks, the mempool now simply calls this function and provides its Vec<Transactions> to be mem-swapped for the empty one in the block.

