### PR TITLE
chore: update to latest rust version in GH action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Update Rust
+        run: rustup update
+      - name: Check Rust version
+        run: rustc --version
       - name: Build
         run: cargo build --verbose
       - name: Run tests


### PR DESCRIPTION
This will make sure we always use the latest version of Rust for the build-step in Github actions.  

Currently with this build works, but tests fail, like it does locally.

![image](https://user-images.githubusercontent.com/1016218/124735901-0d14b680-df49-11eb-9709-0e179296182c.png)
