### PR TITLE
Sequential refactor txs spend tokens if possible

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -379,20 +379,18 @@ impl Block {
         block
     }
 
+    //
+    // TODO - this logic should probably be in the merkle-root class
+    //
     pub fn generate_merkle_root(&self) -> SaitoHash {
+
+	println!("how many txs: {}", self.transactions.len());
+
         let tx_sig_hashes: Vec<SaitoHash> = self
             .transactions
             .iter()
             .map(|tx| tx.get_hash_for_signature())
             .collect();
-
-        /*** KEEPING FOR SPEED REFERENCE TESTS ***
-                let mt = MerkleTree::from_vec(SHA256, tx_sig_hashes);
-                mt.root_hash()
-                    .clone()
-                    .try_into()
-                    .expect("Failed to unwrao merkle root")
-        *****************************************/
 
         let mut mrv: Vec<MerkleTreeLayer> = vec![];
 
@@ -431,7 +429,6 @@ impl Block {
             start_point = mrv.len();
 
             for i in (start_point_old..stop_point).step_by(2) {
-                //println!("looping in hash loop with {:?}", i);
                 if (i + 1) < stop_point {
                     mrv.push(MerkleTreeLayer::new(
                         mrv[i].get_hash(),
@@ -691,6 +688,7 @@ impl Block {
         blockchain: &Blockchain,
         utxoset: &AHashMap<SaitoUTXOSetKey, u64>,
     ) -> bool {
+
         println!(" ... block.validate: (burn fee)  {:?}", create_timestamp());
         //
         // validate burn fee
@@ -896,7 +894,9 @@ impl Block {
         }
 
         let block_merkle_root = block.generate_merkle_root();
+println!("setting merkle root as: {:?}", block_merkle_root);
         block.set_merkle_root(block_merkle_root);
+
         let block_hash = block.generate_hash();
         block.set_hash(block_hash);
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -384,8 +384,6 @@ impl Block {
     //
     pub fn generate_merkle_root(&self) -> SaitoHash {
 
-	println!("how many txs: {}", self.transactions.len());
-
         let tx_sig_hashes: Vec<SaitoHash> = self
             .transactions
             .iter()
@@ -594,6 +592,7 @@ impl Block {
             cv.gt_idx = gt_idx;
             cv.gt_num = gt_num;
         }
+
 
         //
         // validate difficulty
@@ -852,6 +851,21 @@ impl Block {
                 break;
             }
         }
+
+	//
+	// set our initial transactions
+	//
+	let wallet_publickey = wallet.get_publickey();
+	let wallet_privatekey = wallet.get_privatekey();
+	if previous_block_id == 0 {
+	    for i in 0..10 {
+println!("waiting {}", i);
+		let mut transaction = Transaction::generate_vip_transaction(wallet_lock.clone(), wallet_publickey, wallet_publickey, 100000).await;
+		transaction.sign(wallet_privatekey);
+		block.add_transaction(transaction);
+	    }
+	}
+
 
         //
         // create

--- a/src/block.rs
+++ b/src/block.rs
@@ -383,7 +383,6 @@ impl Block {
     // TODO - this logic should probably be in the merkle-root class
     //
     pub fn generate_merkle_root(&self) -> SaitoHash {
-
         let tx_sig_hashes: Vec<SaitoHash> = self
             .transactions
             .iter()
@@ -593,7 +592,6 @@ impl Block {
             cv.gt_num = gt_num;
         }
 
-
         //
         // validate difficulty
         //
@@ -687,7 +685,6 @@ impl Block {
         blockchain: &Blockchain,
         utxoset: &AHashMap<SaitoUTXOSetKey, u64>,
     ) -> bool {
-
         println!(" ... block.validate: (burn fee)  {:?}", create_timestamp());
         //
         // validate burn fee
@@ -852,20 +849,25 @@ impl Block {
             }
         }
 
-	//
-	// set our initial transactions
-	//
-	let wallet_publickey = wallet.get_publickey();
-	let wallet_privatekey = wallet.get_privatekey();
-	if previous_block_id == 0 {
-	    for i in 0..10 {
-println!("generating VIP transaction {}", i);
-		let mut transaction = Transaction::generate_vip_transaction(wallet_lock.clone(), wallet_publickey, wallet_publickey, 100000).await;
-		transaction.sign(wallet_privatekey);
-		block.add_transaction(transaction);
-	    }
-	}
-
+        //
+        // set our initial transactions
+        //
+        let wallet_publickey = wallet.get_publickey();
+        let wallet_privatekey = wallet.get_privatekey();
+        if previous_block_id == 0 {
+            for i in 0..10 {
+                println!("generating VIP transaction {}", i);
+                let mut transaction = Transaction::generate_vip_transaction(
+                    wallet_lock.clone(),
+                    wallet_publickey,
+                    wallet_publickey,
+                    100000,
+                )
+                .await;
+                transaction.sign(wallet_privatekey);
+                block.add_transaction(transaction);
+            }
+        }
 
         //
         // create
@@ -908,7 +910,7 @@ println!("generating VIP transaction {}", i);
         }
 
         let block_merkle_root = block.generate_merkle_root();
-println!("setting merkle root as: {:?}", block_merkle_root);
+        println!("setting merkle root as: {:?}", block_merkle_root);
         block.set_merkle_root(block_merkle_root);
 
         let block_hash = block.generate_hash();

--- a/src/block.rs
+++ b/src/block.rs
@@ -859,7 +859,7 @@ impl Block {
 	let wallet_privatekey = wallet.get_privatekey();
 	if previous_block_id == 0 {
 	    for i in 0..10 {
-println!("waiting {}", i);
+println!("generating VIP transaction {}", i);
 		let mut transaction = Transaction::generate_vip_transaction(wallet_lock.clone(), wallet_publickey, wallet_publickey, 100000).await;
 		transaction.sign(wallet_privatekey);
 		block.add_transaction(transaction);

--- a/src/block.rs
+++ b/src/block.rs
@@ -705,6 +705,10 @@ impl Block {
         let previous_block = blockchain.blocks.get(&self.get_previous_block_hash());
         {
             if !previous_block.is_none() {
+
+		//
+		// new burn fee must be correct
+		//
                 let new_burnfee: u64 =
                     BurnFee::return_burnfee_for_block_produced_at_current_timestamp_in_nolan(
                         previous_block.unwrap().get_burnfee(),
@@ -718,6 +722,22 @@ impl Block {
                     );
                     return false;
                 }
+
+
+		//
+		// routing work must be adequate given block time difference
+		//
+	        let amount_of_routing_work_needed: u64 = 
+		    BurnFee::return_routing_work_needed_to_produce_block_in_nolan(
+	                previous_block.unwrap().get_burnfee(),
+                        self.get_timestamp(),
+                        previous_block.unwrap().get_timestamp(),
+    	            );
+		if self.routing_work_for_creator < amount_of_routing_work_needed {
+	            println!("Error 510293: block lacking adequate routing work from creator");
+	            return false;
+	        }
+
             } else {
                 // TODO assert that this is the first (or second?) block! ?
             }
@@ -798,24 +818,6 @@ impl Block {
             }
         }
         println!(" ... block.validate: (txs valid) {:?}", create_timestamp());
-
-	//
-	// VALIDATE adequate routing work given previous burn fee
-	//
-	    //
-	    // TODO - update after Stephen merge
-	    //
-	    //let amount_of_routing_work_needed = BurnFee::return_routing_work_needed_to_produce_block_in_nolan(
-	    //    burn_fee_previous_block: u64,
-            //    current_block_timestamp: u64,
-            //    previous_block_timestamp: u64,
-    	    //);
-	    //if self.routing_work_for_creator < amount_of_routing_work_needed {
-	    //
-	    //    println!("Error 510293: block lacking adequate routing work from creator");
-	    //    return false;
-	    //
-	    //}
 
 
         //

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -608,25 +608,24 @@ mod tests {
         let top = 157171715;
         let bottom = 11661612;
         let packed = bit_pack(top, bottom);
-        assert_eq!(packed , 157171715*(u64::pow(2,32)) + 11661612);
+        assert_eq!(packed, 157171715 * (u64::pow(2, 32)) + 11661612);
         let (new_top, new_bottom) = bit_unpack(packed);
         assert_eq!(top, new_top);
-        assert_eq!(bottom, new_bottom);   
+        assert_eq!(bottom, new_bottom);
 
         let top = u32::MAX;
         let bottom = u32::MAX;
         let packed = bit_pack(top, bottom);
         let (new_top, new_bottom) = bit_unpack(packed);
         assert_eq!(top, new_top);
-        assert_eq!(bottom, new_bottom);   
-
+        assert_eq!(bottom, new_bottom);
 
         let top = 0;
         let bottom = 1;
         let packed = bit_pack(top, bottom);
         let (new_top, new_bottom) = bit_unpack(packed);
         assert_eq!(top, new_top);
-        assert_eq!(bottom, new_bottom);   
+        assert_eq!(bottom, new_bottom);
     }
 
     #[tokio::test]

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -1,8 +1,8 @@
-use crate::crypto::{sign, SaitoPublicKey, SaitoSignature, SaitoHash};
+use crate::crypto::{sign, SaitoHash, SaitoPublicKey, SaitoSignature};
 use crate::wallet::Wallet;
 use serde::{Deserialize, Serialize};
-use std::{sync::Arc};
-use tokio::sync::{RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -24,17 +24,19 @@ impl Hop {
         }
     }
 
-    pub async fn generate_hop(wallet_lock : Arc<RwLock<Wallet>>, to_publickey : SaitoPublicKey, hash_to_sign : SaitoHash) -> Hop {
-
-	let wallet = wallet_lock.read().await;
+    pub async fn generate_hop(
+        wallet_lock: Arc<RwLock<Wallet>>,
+        to_publickey: SaitoPublicKey,
+        hash_to_sign: SaitoHash,
+    ) -> Hop {
+        let wallet = wallet_lock.read().await;
         let mut hop = Hop::new();
 
         hop.set_from(wallet.get_publickey());
         hop.set_to(to_publickey);
         hop.set_sig(sign(&hash_to_sign, wallet.get_privatekey()));
 
-	hop
-
+        hop
     }
 
     pub fn get_from(&self) -> SaitoPublicKey {
@@ -49,20 +51,18 @@ impl Hop {
         self.sig
     }
 
-    pub fn set_from(&mut self, from : SaitoPublicKey) {
+    pub fn set_from(&mut self, from: SaitoPublicKey) {
         self.from = from
     }
 
-    pub fn set_to(&mut self, to : SaitoPublicKey) {
+    pub fn set_to(&mut self, to: SaitoPublicKey) {
         self.to = to
     }
 
-    pub fn set_sig(&mut self, sig : SaitoSignature) {
+    pub fn set_sig(&mut self, sig: SaitoSignature) {
         self.sig = sig
     }
-
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -75,4 +75,3 @@ mod tests {
         assert_eq!(1, 1);
     }
 }
-

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -1,0 +1,78 @@
+use crate::crypto::{sign, SaitoPublicKey, SaitoSignature, SaitoHash};
+use crate::wallet::Wallet;
+use serde::{Deserialize, Serialize};
+use std::{sync::Arc};
+use tokio::sync::{RwLock};
+
+#[serde_with::serde_as]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct Hop {
+    #[serde_as(as = "[_; 33]")]
+    from: SaitoPublicKey,
+    #[serde_as(as = "[_; 33]")]
+    to: SaitoPublicKey,
+    #[serde_as(as = "[_; 64]")]
+    sig: SaitoSignature,
+}
+
+impl Hop {
+    pub fn new() -> Self {
+        Hop {
+            from: [0; 33],
+            to: [0; 33],
+            sig: [0; 64],
+        }
+    }
+
+    pub async fn generate_hop(wallet_lock : Arc<RwLock<Wallet>>, to_publickey : SaitoPublicKey, hash_to_sign : SaitoHash) -> Hop {
+
+	let wallet = wallet_lock.read().await;
+        let mut hop = Hop::new();
+
+        hop.set_from(wallet.get_publickey());
+        hop.set_to(to_publickey);
+        hop.set_sig(sign(&hash_to_sign, wallet.get_privatekey()));
+
+	hop
+
+    }
+
+    pub fn get_from(&self) -> SaitoPublicKey {
+        self.from
+    }
+
+    pub fn get_to(&self) -> SaitoPublicKey {
+        self.to
+    }
+
+    pub fn get_sig(&self) -> SaitoSignature {
+        self.sig
+    }
+
+    pub fn set_from(&mut self, from : SaitoPublicKey) {
+        self.from = from
+    }
+
+    pub fn set_to(&mut self, to : SaitoPublicKey) {
+        self.to = to
+    }
+
+    pub fn set_sig(&mut self, sig : SaitoSignature) {
+        self.sig = sig
+    }
+
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn hop_new_test() {
+        let hop = Hop::new();
+        assert_eq!(1, 1);
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod burnfee;
 pub mod consensus;
 pub mod crypto;
 pub mod golden_ticket;
+pub mod hop;
 pub mod mempool;
 pub mod merkle;
 pub mod miner;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -385,7 +385,7 @@ pub async fn run(
 					//
 					// calculating routing work requires this stuff done
 					//
-					transaction.pre_validation_calculations_parallelizable();
+					transaction.pre_validation_calculations_parallelizable(wallet_publickey);
 
 //println!("tx has fees: {}", transaction.get_total_fees());
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -2,7 +2,7 @@ use crate::{
     block::Block,
     blockchain::Blockchain,
     burnfee::BurnFee,
-    crypto::{SaitoHash, SaitoPublicKey, SaitoPrivateKey},
+    crypto::{SaitoPublicKey, SaitoPrivateKey},
     consensus::SaitoMessage,
     golden_ticket::GoldenTicket,
     time::create_timestamp,
@@ -100,6 +100,10 @@ impl Mempool {
 
         let tx_sig_to_insert = transaction.get_signature();
 	let routing_work_available_for_me = transaction.get_routing_work_for_publickey(self.mempool_publickey);
+
+println!("total fees in tx: {}", transaction.get_total_fees());
+println!("routing paths: {:?}", transaction.get_path());
+println!("routing work for me in this tx: {}", routing_work_available_for_me);
 
         if self
             .transactions

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -139,14 +139,14 @@ impl Slip {
     //
     // output slips are signed as zero'd out byte arrays. we have
     // a separate function to handle them as otherwise we may
-    // generate an incorrect signature after we have updated the 
+    // generate an incorrect signature after we have updated the
     // transaction outputs with the proper UUID for insertion into
     // the utxoset.
     //
     pub fn serialize_output_for_signature(&self) -> Vec<u8> {
         let mut vbytes: Vec<u8> = vec![];
         vbytes.extend(&self.publickey);
-        vbytes.extend(&[0; 32]); 
+        vbytes.extend(&[0; 32]);
         vbytes.extend(&self.amount.to_be_bytes());
         vbytes.extend(&(self.slip_ordinal.to_be_bytes()));
         vbytes.extend(&(self.slip_type as u32).to_be_bytes());

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -122,10 +122,29 @@ impl Slip {
     //
     // Serialization
     //
-    pub fn serialize_for_signature(&self) -> Vec<u8> {
+    pub fn serialize_input_for_signature(&self) -> Vec<u8> {
         let mut vbytes: Vec<u8> = vec![];
         vbytes.extend(&self.publickey);
         vbytes.extend(&self.uuid);
+        vbytes.extend(&self.amount.to_be_bytes());
+        vbytes.extend(&(self.slip_ordinal.to_be_bytes()));
+        vbytes.extend(&(self.slip_type as u32).to_be_bytes());
+        vbytes
+    }
+
+    //
+    // Serialization
+    //
+    // output slips are signed as zero'd out byte arrays. we have
+    // a separate function to handle them as otherwise we may
+    // generate an incorrect signature after we have updated the 
+    // transaction outputs with the proper UUID for insertion into
+    // the utxoset.
+    //
+    pub fn serialize_output_for_signature(&self) -> Vec<u8> {
+        let mut vbytes: Vec<u8> = vec![];
+        vbytes.extend(&self.publickey);
+        vbytes.extend(&[0; 32]); 
         vbytes.extend(&self.amount.to_be_bytes());
         vbytes.extend(&(self.slip_ordinal.to_be_bytes()));
         vbytes.extend(&(self.slip_type as u32).to_be_bytes());

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -14,6 +14,8 @@ pub const SLIP_SIZE: usize = 75;
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, Eq, PartialEq, TryFromByte)]
 pub enum SlipType {
     Normal,
+    VipInput,
+    VipOutput,
     MinerInput,
     MinerOutput,
     RouterInput,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -117,8 +117,8 @@ impl Transaction {
 	let wallet_publickey = wallet.get_publickey();
 
         let available_balance = wallet.get_available_balance();
-println!("in generate transaction ab: {}", available_balance);
         let total_requested = with_payment + with_fee;
+//println!("in generate transaction ab: {} and pr: {} and fr: {}", available_balance, with_payment, with_fee);
 
 	if available_balance >= total_requested {
 
@@ -135,6 +135,8 @@ println!("in generate transaction ab: {}", available_balance);
             output.set_publickey(to_publickey);
             output.set_amount(with_payment);
             transaction.add_output(output);
+
+//println!("inputs are: {}", transaction.get_inputs().len());
 
 	    return transaction;
 
@@ -601,6 +603,11 @@ println!("in generate transaction ab: {}", available_balance);
         // we make an exception for fee and vip transactions, which may be pulling revenue from the
         // treasury in some amount.
         if self.total_out > self.total_in && self.get_transaction_type() != TransactionType::Fee && self.get_transaction_type() != TransactionType::Vip {
+
+println!("{} in and {} out", self.total_in, self.total_out);
+for z in self.get_outputs() {
+    println!("{:?} --- ", z.get_amount());
+}
             println!("ERROR 672941: transaction spends more than it has available");
             return false;
         }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -89,6 +89,9 @@ impl Wallet {
         let mut nolan_out: u64 = 0;
 	let my_publickey = self.get_publickey();
 
+        //
+        // grab inputs
+        //
         for slip in &mut self.slips {
             if !slip.get_spent() {
 
@@ -102,24 +105,26 @@ impl Wallet {
         	    input.set_uuid(slip.get_uuid());
 		    inputs.push(input);
 
-println!("creating {} token-carrying tx with uuid {:?}", slip.get_amount(), slip.get_uuid());
-
 		    slip.set_spent(true);
 
 		}
 
-	        if nolan_in > nolan_requested {
-		    nolan_out = nolan_in - nolan_requested;
-		}
-
-		// change address
-	        let mut output = Slip::new();
-                output.set_publickey(my_publickey);
-	        output.set_amount(nolan_out);
-		outputs.push(output);
-
 	    }
 	}
+
+
+        // 
+        // create outputs 
+        // 
+        if nolan_in > nolan_requested {
+	    nolan_out = nolan_in - nolan_requested;
+	}
+
+	// change address
+        let mut output = Slip::new();
+        output.set_publickey(my_publickey);
+        output.set_amount(nolan_out);
+	outputs.push(output);
 
 
 	//
@@ -142,8 +147,6 @@ println!("creating {} token-carrying tx with uuid {:?}", slip.get_amount(), slip
             output.set_uuid([0; 32]);
 	    outputs.push(output);
 	}
-
-println!("created tx with # inputs: {}", inputs.len());
 
         return (inputs, outputs);
     }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -34,27 +34,32 @@ impl Wallet {
                 self.delete_slip(input);
             }
             for output in tx.get_outputs() {
-                self.add_slip(block, tx, output, block.get_lc());
+		if output.get_amount() > 0 {
+                    self.add_slip(block, tx, output, block.get_lc());
+                }
             }
         }
     }
 
     pub fn add_slip(&mut self, block: &Block, transaction: &Transaction, slip: &Slip, lc: bool) {
+
         let mut wallet_slip = WalletSlip::new();
 
         wallet_slip.set_uuid(transaction.get_hash_for_signature());
         wallet_slip.set_utxokey(slip.get_utxoset_key());
         wallet_slip.set_amount(slip.get_amount());
+        wallet_slip.set_slip_ordinal(slip.get_slip_ordinal());
         wallet_slip.set_block_id(block.get_id());
         wallet_slip.set_block_hash(block.get_hash());
         wallet_slip.set_lc(lc);
 
-        self.slips.push(WalletSlip::new());
+        self.slips.push(wallet_slip);
+
     }
 
     pub fn delete_slip(&mut self, slip: &Slip) {
         self.slips.retain(|x| {
-            x.get_uuid() != slip.get_uuid() && x.get_slip_ordinal() != slip.get_slip_ordinal()
+            x.get_uuid() != slip.get_uuid() || x.get_slip_ordinal() != slip.get_slip_ordinal()
         });
     }
 
@@ -97,6 +102,8 @@ impl Wallet {
         	    input.set_uuid(slip.get_uuid());
 		    inputs.push(input);
 
+println!("creating {} token-carrying tx with uuid {:?}", slip.get_amount(), slip.get_uuid());
+
 		    slip.set_spent(true);
 
 		}
@@ -135,6 +142,8 @@ impl Wallet {
             output.set_uuid([0; 32]);
 	    outputs.push(output);
 	}
+
+println!("created tx with # inputs: {}", inputs.len());
 
         return (inputs, outputs);
     }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -17,7 +17,6 @@ pub struct Wallet {
 }
 
 impl Wallet {
-
     #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Self {
         let (publickey, privatekey) = generate_keys();
@@ -34,7 +33,7 @@ impl Wallet {
                 self.delete_slip(input);
             }
             for output in tx.get_outputs() {
-		if output.get_amount() > 0 {
+                if output.get_amount() > 0 {
                     self.add_slip(block, tx, output, block.get_lc());
                 }
             }
@@ -42,7 +41,6 @@ impl Wallet {
     }
 
     pub fn add_slip(&mut self, block: &Block, transaction: &Transaction, slip: &Slip, lc: bool) {
-
         let mut wallet_slip = WalletSlip::new();
 
         wallet_slip.set_uuid(transaction.get_hash_for_signature());
@@ -54,7 +52,6 @@ impl Wallet {
         wallet_slip.set_lc(lc);
 
         self.slips.push(wallet_slip);
-
     }
 
     pub fn delete_slip(&mut self, slip: &Slip) {
@@ -74,79 +71,69 @@ impl Wallet {
     pub fn get_available_balance(&self) -> u64 {
         let mut available_balance: u64 = 0;
         for slip in &self.slips {
-	    if !slip.get_spent() {
-		available_balance += slip.get_amount();
-	    }
-	}
-	return available_balance;
+            if !slip.get_spent() {
+                available_balance += slip.get_amount();
+            }
+        }
+        return available_balance;
     }
 
-    pub fn generate_slips(&mut self, nolan_requested : u64) -> (Vec<Slip>, Vec<Slip>) {
-
+    pub fn generate_slips(&mut self, nolan_requested: u64) -> (Vec<Slip>, Vec<Slip>) {
         let mut inputs: Vec<Slip> = vec![];
         let mut outputs: Vec<Slip> = vec![];
         let mut nolan_in: u64 = 0;
         let mut nolan_out: u64 = 0;
-	let my_publickey = self.get_publickey();
+        let my_publickey = self.get_publickey();
 
         //
         // grab inputs
         //
         for slip in &mut self.slips {
             if !slip.get_spent() {
+                if nolan_in < nolan_requested {
+                    nolan_in += slip.get_amount();
 
-		if nolan_in < nolan_requested {
-
-  	            nolan_in += slip.get_amount();
-
-	            let mut input = Slip::new();
+                    let mut input = Slip::new();
                     input.set_publickey(my_publickey);
-	            input.set_amount(slip.get_amount());
-        	    input.set_uuid(slip.get_uuid());
-		    inputs.push(input);
+                    input.set_amount(slip.get_amount());
+                    input.set_uuid(slip.get_uuid());
+                    inputs.push(input);
 
-		    slip.set_spent(true);
+                    slip.set_spent(true);
+                }
+            }
+        }
 
-		}
-
-	    }
-	}
-
-
-        // 
-        // create outputs 
-        // 
+        //
+        // create outputs
+        //
         if nolan_in > nolan_requested {
-	    nolan_out = nolan_in - nolan_requested;
-	}
+            nolan_out = nolan_in - nolan_requested;
+        }
 
-	// change address
+        // change address
         let mut output = Slip::new();
         output.set_publickey(my_publickey);
         output.set_amount(nolan_out);
-	outputs.push(output);
+        outputs.push(output);
 
-
-	//
-	// ensure not empty
-	//
-	if inputs.len() == 0 {
-
-	    let mut input = Slip::new();
+        //
+        // ensure not empty
+        //
+        if inputs.len() == 0 {
+            let mut input = Slip::new();
             input.set_publickey(my_publickey);
-	    input.set_amount(0);
+            input.set_amount(0);
             input.set_uuid([0; 32]);
-	    inputs.push(input);
-
-	}
-	if outputs.len() == 0 {
-
-	    let mut output = Slip::new();
+            inputs.push(input);
+        }
+        if outputs.len() == 0 {
+            let mut output = Slip::new();
             output.set_publickey(my_publickey);
-	    output.set_amount(0);
+            output.set_amount(0);
             output.set_uuid([0; 32]);
-	    outputs.push(output);
-	}
+            outputs.push(output);
+        }
 
         return (inputs, outputs);
     }
@@ -220,7 +207,7 @@ impl WalletSlip {
             block_hash: [0; 32],
             lc: true,
             slip_ordinal: 0,
-	    spent: false,
+            spent: false,
         }
     }
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -17,6 +17,7 @@ pub struct Wallet {
 }
 
 impl Wallet {
+
     #[allow(clippy::clippy::new_without_default)]
     pub fn new() -> Self {
         let (publickey, privatekey) = generate_keys();
@@ -66,7 +67,76 @@ impl Wallet {
     }
 
     pub fn get_available_balance(&self) -> u64 {
-	0
+        let mut available_balance: u64 = 0;
+        for slip in &self.slips {
+	    if !slip.get_spent() {
+		available_balance += slip.get_amount();
+	    }
+	}
+	return available_balance;
+    }
+
+    pub fn generate_slips(&mut self, nolan_requested : u64) -> (Vec<Slip>, Vec<Slip>) {
+
+        let mut inputs: Vec<Slip> = vec![];
+        let mut outputs: Vec<Slip> = vec![];
+        let mut nolan_in: u64 = 0;
+        let mut nolan_out: u64 = 0;
+	let my_publickey = self.get_publickey();
+
+        for slip in &mut self.slips {
+            if !slip.get_spent() {
+
+		if nolan_in < nolan_requested {
+
+  	            nolan_in += slip.get_amount();
+
+	            let mut input = Slip::new();
+                    input.set_publickey(my_publickey);
+	            input.set_amount(slip.get_amount());
+        	    input.set_uuid(slip.get_uuid());
+		    inputs.push(input);
+
+		    slip.set_spent(true);
+
+		}
+
+	        if nolan_in > nolan_requested {
+		    nolan_out = nolan_in - nolan_requested;
+		}
+
+		// change address
+	        let mut output = Slip::new();
+                output.set_publickey(my_publickey);
+	        output.set_amount(nolan_out);
+		outputs.push(output);
+
+	    }
+	}
+
+
+	//
+	// ensure not empty
+	//
+	if inputs.len() == 0 {
+
+	    let mut input = Slip::new();
+            input.set_publickey(my_publickey);
+	    input.set_amount(0);
+            input.set_uuid([0; 32]);
+	    inputs.push(input);
+
+	}
+	if outputs.len() == 0 {
+
+	    let mut output = Slip::new();
+            output.set_publickey(my_publickey);
+	    output.set_amount(0);
+            output.set_uuid([0; 32]);
+	    outputs.push(output);
+	}
+
+        return (inputs, outputs);
     }
 
     pub fn sign(&self, message_bytes: &[u8]) -> SaitoSignature {
@@ -108,6 +178,14 @@ impl Wallet {
 /// The `WalletSlip` stores the essential information needed to track which
 /// slips are spendable and managing them as they move onto and off of the
 /// longest-chain.
+///
+/// Please note that the wallet in this Saito Rust client is intended primarily
+/// to hold the public/privatekey and that slip-spending and tracking code is
+/// not coded in a way intended to be robust against chain-reorganizations but
+/// rather for testing of basic functions like transaction creation. Slips that
+/// are spent on one fork are not recaptured on chains, for instance, and once
+/// a slip is spent it is marked as spent.
+///
 #[derive(Clone, Debug)]
 pub struct WalletSlip {
     uuid: SaitoHash,
@@ -117,6 +195,7 @@ pub struct WalletSlip {
     block_hash: SaitoHash,
     lc: bool,
     slip_ordinal: u8,
+    spent: bool,
 }
 
 impl WalletSlip {
@@ -129,6 +208,7 @@ impl WalletSlip {
             block_hash: [0; 32],
             lc: true,
             slip_ordinal: 0,
+	    spent: false,
         }
     }
 
@@ -158,6 +238,14 @@ impl WalletSlip {
 
     pub fn get_slip_ordinal(&self) -> u8 {
         self.slip_ordinal
+    }
+
+    pub fn get_spent(&self) -> bool {
+        self.spent
+    }
+
+    pub fn set_spent(&mut self, spent: bool) {
+        self.spent = spent;
     }
 
     pub fn set_uuid(&mut self, hash: SaitoHash) {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -65,6 +65,10 @@ impl Wallet {
         self.publickey
     }
 
+    pub fn get_available_balance(&self) -> u64 {
+	0
+    }
+
     pub fn sign(&self, message_bytes: &[u8]) -> SaitoSignature {
         sign(message_bytes, self.privatekey)
     }


### PR DESCRIPTION
This is a decent stopping point for a merge. Some of the features implemented in this push are needed for testing and development. Others constitute core functionality. Here are the changes.

We are flushing actual SAITO into the network through the creation of VIP transactions in block #1 -- these are created manually in block.add_block() by invoking a special function in transactions. For now the block validation code will permit these transactions to slip through as OK.

The wallet is saving the slips when a block is added to the end of the longest chain. This is not robust code and we intend to remove it -- it adds everything, not just the transactions for itself. The point is to be able to generate valid spendable slips from the mempool during the next loop of block creation. This permits these transactions to include fees. As part of creating these transactions, the mempool now adds routing path as well. By default we are adding 2 hops as a sanity check that this halves the fees.

The mempool now tracks the total amount of routing work in its mempool and uses that as the figure to determine when it can create a block. Next up is the validation of the routing sigs. From there we can move on to the selection of the winning routing node based on the Golden Ticket and the creation and then validation of fee transactions.