### PR TITLE
Router and Miner Payouts

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -831,11 +831,12 @@ impl Block {
 
 
         //
-        // fee transactions and golden tickets
+        // fee transactions
         //
-        // set hash_for_signature for fee_tx as we cannot mutably fetch it
-        // during merkle_root generation as those functions require parallel
-        // processing in block validation. So some extra code here.
+        // we grab the fee transaction created in the cv function and run
+	// a quick hash of it, comparing that with the hash of the fee-tx
+	// that exists in the block. if they match, we're OK with th block
+	// including this fee transaction.
         //
         if cv.ft_idx != usize::MAX {
             if !cv.fee_transaction.is_none() {
@@ -843,11 +844,12 @@ impl Block {
                 //
             	// fee-transaction must still pass validation rules
             	//
+		// we are OK with just doing a hash check as the other
+		// requirements are covered in the validation function.
+		//
             	let fee_tx = cv.fee_transaction.unwrap();
 	    	let cv_ft_hash = hash(&fee_tx.serialize_for_signature());
 	    	let block_ft_hash = hash(&self.transactions[cv.ft_idx].serialize_for_signature());
-
-println!("hashes {:?} {:?}", cv_ft_hash, block_ft_hash);
 
 	    	if cv_ft_hash != block_ft_hash {
 	            println!("ERROR 627428: block fee transaction doesn't match cv fee transaction");

--- a/src/block.rs
+++ b/src/block.rs
@@ -621,7 +621,6 @@ impl Block {
             //
             // fee transaction added to consensus values
             //
-            cv.fee_transaction = Some(fee_transaction);
             cv.ft_idx = ft_idx_option;
             cv.ft_num = ft_num;
             cv.gt_idx = gt_idx_option;
@@ -878,7 +877,7 @@ impl Block {
 	// that exists in the block. if they match, we're OK with th block
 	// including this fee transaction.
         //
-        if cv.ft_idx != usize::MAX {
+        if !cv.ft_idx.is_none() {
             if !cv.fee_transaction.is_none() {
             
                 //
@@ -889,7 +888,7 @@ impl Block {
 		//
             	let fee_tx = cv.fee_transaction.unwrap();
 	    	let cv_ft_hash = hash(&fee_tx.serialize_for_signature());
-	    	let block_ft_hash = hash(&self.transactions[cv.ft_idx].serialize_for_signature());
+	    	let block_ft_hash = hash(&self.transactions[cv.ft_idx.unwrap()].serialize_for_signature());
 
 	    	if cv_ft_hash != block_ft_hash {
 	            println!("ERROR 627428: block fee transaction doesn't match cv fee transaction");

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -167,11 +167,10 @@ impl Mempool {
     ///
     /// Calculates the work available in mempool to produce a block
     ///
-    pub async fn calculate_work_available(&self) -> u64 {
+    pub fn calculate_work_available(&self) -> u64 {
         if self.routing_work_in_mempool > 0 {
             return self.routing_work_in_mempool;
         }
-
         return 0;
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -383,22 +383,27 @@ impl Transaction {
 	let mut aggregate_routing_work: u64 = self.get_total_fees();
 	let mut routing_work_this_hop: u64 = aggregate_routing_work;
         let mut work_by_hop : Vec<u64> = vec![];
+	work_by_hop.push(aggregate_routing_work);
 
-	for i in 1..self.path.len() {
+	for _i in 1..self.path.len() {
 	    let new_routing_work_this_hop: u64  = routing_work_this_hop / 2;
 	    aggregate_routing_work += new_routing_work_this_hop;
+            routing_work_this_hop = new_routing_work_this_hop;
 	    work_by_hop.push(aggregate_routing_work);
 	}
+
+println!("{:?}", work_by_hop);
 
 	//
         //
         // find winning routing node
         //
         let x = U256::from_big_endian(&random_hash);
-        let y: u64 = 10_000_000_000;
-        let z = U256::from_big_endian(&y.to_be_bytes());
+        let z = U256::from_big_endian(&aggregate_routing_work.to_be_bytes());
         let (zy, _bolres) = x.overflowing_rem(z);
         let winning_routing_work_in_nolan = zy.low_u64();
+
+println!("wrwin: {}", winning_routing_work_in_nolan);
 
 	for i in 0.. work_by_hop.len() {
 	    if winning_routing_work_in_nolan <= work_by_hop[i] {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -581,7 +581,7 @@ println!("work by hop: {:?}", work_by_hop);
     pub fn pre_validation_calculations_cumulative_work(&mut self, cumulative_work: u64) -> u64 {
         return cumulative_work + self.routing_work_for_creator;
     }
-    pub fn pre_validation_calculations_parallelizable(&mut self) -> bool {
+    pub fn pre_validation_calculations_parallelizable(&mut self, creator_publickey : SaitoPublicKey) -> bool {
         //
         // and save the hash_for_signature so we can use it later...
         //
@@ -627,11 +627,11 @@ println!("work by hop: {:?}", work_by_hop);
             self.total_fees = nolan_in - nolan_out;
         }
 
-	      //
-	      // we also need to know how much routing work exists and is available
-	      // for the block producer, to ensure that they have met the conditions
-	      // required by the burn fee for block production.
-	      //
+        //
+        // we also need to know how much routing work exists and is available
+        // for the block producer, to ensure that they have met the conditions
+        // required by the burn fee for block production.
+        //
         self.routing_work_for_creator = self.get_routing_work_for_publickey(creator_publickey);
 
         true


### PR DESCRIPTION
This push adds payments for routing nodes and mining nodes.

The fee-bearing transaction is generated and attached to the {cv} object.

It is pushed directly into the transactions vector on block creation.

And it is hashed and checked against the in-block fee transaction during validation.