### PR TITLE
Initial Support : Automatic Transaction Rebroadcasting

### DIFF
--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -60,15 +60,13 @@ pub async fn main() -> saito_rust::Result<()> {
                 // sign ...
                 transaction.sign(privatekey);
 
+		// make sure we know fees etc.
+		transaction.pre_validation_calculations_parallelizable(publickey);
                 transactions.push(transaction);
 
 	    }
 
             for mut tx in transactions {
-
-	        tx.add_hop_to_path(wallet_lock.clone(), publickey).await;
-	        tx.add_hop_to_path(wallet_lock.clone(), publickey).await;
-
                 let bytes: Vec<u8> = tx.serialize_for_net();
                 let _res = client
                     .post("http://localhost:3030/transactions")

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -1,9 +1,7 @@
 use saito_rust::{
     blockchain::Blockchain,
-    crypto::{generate_random_bytes, hash, SaitoPrivateKey, SaitoPublicKey},
     mempool::Mempool,
     miner::Miner,
-    slip::Slip,
     transaction::Transaction,
     wallet::Wallet,
 };
@@ -46,9 +44,31 @@ pub async fn main() -> saito_rust::Result<()> {
         let client = reqwest::Client::new();
         // sleep(Duration::from_millis(5000));
         loop {
-            let transactions =
-                generate_transactions(publickey, privatekey, txs_to_generate, bytes_per_tx);
-            for tx in transactions.iter() {
+
+            let mut transactions: Vec<Transaction> = vec![];
+
+	    for _i in 0..txs_to_generate {
+
+                let mut transaction = Transaction::generate_transaction(wallet_lock.clone(), publickey, 5000, 5000).await;
+                transaction.set_message(
+                    (0..bytes_per_tx)
+                        .into_par_iter()
+                        .map(|_| rand::random::<u8>())
+                        .collect(),
+                );
+
+                // sign ...
+                transaction.sign(privatekey);
+
+                transactions.push(transaction);
+
+	    }
+
+            for mut tx in transactions {
+
+	        tx.add_hop_to_path(wallet_lock.clone(), publickey).await;
+	        tx.add_hop_to_path(wallet_lock.clone(), publickey).await;
+
                 let bytes: Vec<u8> = tx.serialize_for_net();
                 let _res = client
                     .post("http://localhost:3030/transactions")
@@ -113,40 +133,4 @@ pub async fn run(
     Ok(())
 }
 
-pub fn generate_transactions(
-    publickey: SaitoPublicKey,
-    privatekey: SaitoPrivateKey,
-    txs_to_generate: u32,
-    bytes_per_tx: u32,
-) -> Vec<Transaction> {
-    (0..txs_to_generate)
-        .into_par_iter()
-        .map(|_| {
-            let mut transaction = Transaction::new();
-            transaction.set_message(
-                (0..bytes_per_tx)
-                    .into_par_iter()
-                    .map(|_| rand::random::<u8>())
-                    .collect(),
-            );
 
-            // as fake transactions, we set the UUID arbitrarily
-            let mut input1 = Slip::new();
-            input1.set_publickey(publickey);
-            input1.set_amount(1000000);
-            input1.set_uuid(hash(&generate_random_bytes(32)));
-
-            let mut output1 = Slip::new();
-            output1.set_publickey(publickey);
-            output1.set_amount(1000000);
-            output1.set_uuid([0; 32]);
-
-            transaction.add_input(input1);
-            transaction.add_output(output1);
-
-            // sign ...
-            transaction.sign(privatekey);
-            transaction
-        })
-        .collect()
-}

--- a/src/block.rs
+++ b/src/block.rs
@@ -831,11 +831,12 @@ impl Block {
 
 
         //
-        // fee transactions and golden tickets
+        // fee transactions
         //
-        // set hash_for_signature for fee_tx as we cannot mutably fetch it
-        // during merkle_root generation as those functions require parallel
-        // processing in block validation. So some extra code here.
+        // we grab the fee transaction created in the cv function and run
+	// a quick hash of it, comparing that with the hash of the fee-tx
+	// that exists in the block. if they match, we're OK with th block
+	// including this fee transaction.
         //
         if cv.ft_idx != usize::MAX {
             if !cv.fee_transaction.is_none() {
@@ -843,11 +844,12 @@ impl Block {
                 //
             	// fee-transaction must still pass validation rules
             	//
+		// we are OK with just doing a hash check as the other
+		// requirements are covered in the validation function.
+		//
             	let fee_tx = cv.fee_transaction.unwrap();
 	    	let cv_ft_hash = hash(&fee_tx.serialize_for_signature());
 	    	let block_ft_hash = hash(&self.transactions[cv.ft_idx].serialize_for_signature());
-
-println!("hashes {:?} {:?}", cv_ft_hash, block_ft_hash);
 
 	    	if cv_ft_hash != block_ft_hash {
 	            println!("ERROR 627428: block fee transaction doesn't match cv fee transaction");

--- a/src/block.rs
+++ b/src/block.rs
@@ -39,7 +39,11 @@ pub struct DataToValidate {
     // expected difficulty
     pub expected_difficulty: u64,
     // rebroadcast txs
-    pub rebroadcasts: Vec<Transaction>
+    pub rebroadcasts: Vec<Transaction>,
+    // number of rebroadcast slips
+    pub total_rebroadcast_slips: u64,
+    // number of rebroadcast txs
+    pub total_rebroadcast_nolan: u64,
 }
 impl DataToValidate {
     #[allow(clippy::too_many_arguments)]
@@ -52,6 +56,8 @@ impl DataToValidate {
             gt_idx: None,
             expected_difficulty: 0,
     	    rebroadcasts: vec![],
+    	    total_rebroadcast_slips: 0,
+    	    total_rebroadcast_nolan: 0,
         }
     }
 }
@@ -517,21 +523,6 @@ impl Block {
             //
 	    if total_fees == 0 {
 
-            //
-            // find winning router
-            //
-            let x = U256::from_big_endian(&miner_random);
-            //
-            // TODO - y cannot be zero or divide by zero
-            //
-            let y = match total_fees {
-                0 => 100,
-                diff => diff,
-            };
-
-            let z = U256::from_big_endian(&y.to_be_bytes());
-            let (winning_router, _bolres) = x.overflowing_rem(z);
-            let winning_nolan_in_fees = winning_router.low_u64();
 
 	    } else {
 
@@ -657,6 +648,8 @@ impl Block {
         //
         // calculate automatic transaction rebroadcasts / ATR / atr
         //
+	if self.get_id() > 2 {
+
 	let pruned_block_hash = blockchain.blockring.get_longest_chain_block_hash_by_block_id(self.get_id()-2);
 println!("pruned block hash: {:?}", pruned_block_hash);
 
@@ -696,6 +689,7 @@ println!("WE HAVE A TX TO PRUNE / REBROADCAST!");
 	    cv.total_rebroadcast_slips = total_rebroadcast_slips;
 	    cv.total_rebroadcast_nolan = total_rebroadcast_nolan;
 
+	}
 	}
 
         cv
@@ -745,8 +739,6 @@ println!("WE HAVE A TX TO PRUNE / REBROADCAST!");
         //
         let mut cumulative_fees = 0;
         let mut cumulative_work = 0;
-        let mut hgt = false;
-        let mut hft = false;
 
         let mut has_golden_ticket = false;
         let mut has_fee_transaction = false;

--- a/src/block.rs
+++ b/src/block.rs
@@ -471,6 +471,8 @@ impl Block {
         let mut gt_idx_option: Option<usize> = None;
         let mut ft_idx_option: Option<usize> = None;
         let mut total_fees = 0;
+	let mut total_rebroadcast_slips: u64 = 0;
+	let mut total_rebroadcast_nolan: u64 = 0;
         let miner_publickey;
         let router_publickey;
 
@@ -655,8 +657,6 @@ impl Block {
         //
         // calculate automatic transaction rebroadcasts / ATR / atr
         //
-	let mut total_rebroadcast_slips: u64 = 0;
-	let mut total_rebroadcast_nolan: u64 = 0;
 	let pruned_block_hash = blockchain.blockring.get_longest_chain_block_hash_by_block_id(self.get_id()-2);
 println!("pruned block hash: {:?}", pruned_block_hash);
 
@@ -692,6 +692,10 @@ println!("WE HAVE A TX TO PRUNE / REBROADCAST!");
 		    }
 		}
 	    }
+
+	    cv.total_rebroadcast_slips = total_rebroadcast_slips;
+	    cv.total_rebroadcast_nolan = total_rebroadcast_nolan;
+
 	}
 
         cv
@@ -981,6 +985,7 @@ println!("WE HAVE A TX TO PRUNE / REBROADCAST!");
         wallet_lock: Arc<RwLock<Wallet>>,
         blockchain_lock: Arc<RwLock<Blockchain>>,
     ) -> Block {
+
         let blockchain = blockchain_lock.read().await;
         let wallet = wallet_lock.read().await;
 

--- a/src/block.rs
+++ b/src/block.rs
@@ -621,7 +621,6 @@ impl Block {
             //
             // fee transaction added to consensus values
             //
-            cv.fee_transaction = Some(fee_transaction);
             cv.ft_idx = ft_idx_option;
             cv.ft_num = ft_num;
             cv.gt_idx = gt_idx_option;
@@ -878,7 +877,7 @@ impl Block {
 	// that exists in the block. if they match, we're OK with th block
 	// including this fee transaction.
         //
-        if cv.ft_idx != usize::MAX {
+        if !cv.ft_idx.is_none() {
             if !cv.fee_transaction.is_none() {
             
                 //
@@ -889,7 +888,7 @@ impl Block {
 		//
             	let fee_tx = cv.fee_transaction.unwrap();
 	    	let cv_ft_hash = hash(&fee_tx.serialize_for_signature());
-	    	let block_ft_hash = hash(&self.transactions[cv.ft_idx].serialize_for_signature());
+	    	let block_ft_hash = hash(&self.transactions[cv.ft_idx.unwrap()].serialize_for_signature());
 
 	    	if cv_ft_hash != block_ft_hash {
 	            println!("ERROR 627428: block fee transaction doesn't match cv fee transaction");

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -86,16 +86,44 @@ impl Mempool {
 
     // this handles any transactions broadcast on the same system. it receives the transaction
     // directly and so does not validate against the UTXOset etc.
-    pub fn add_transaction(&mut self, transaction: Transaction) -> AddTransactionResult {
+    pub async fn add_transaction(&mut self, mut transaction: Transaction) -> AddTransactionResult {
         let tx_sig_to_insert = transaction.get_signature();
+
+	/////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	// TODO -- this is just testing -- remove async too    // 
+	/////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	let publickey;
+	{
+	    let wallet = self.wallet_lock.read().await;
+	    publickey = wallet.get_publickey();
+	}
+
+        transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
+        transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
+	//
+	// note that this calculates the total fees, so needs to 
+	// be handled well. Stephen may have some ideas on how we
+	// can better name these functions. what this is really 
+	// doing is filling in the total fee amounts so that we 
+	// can calculate the routing work below to know how much
+	// this contributes to our mempool.
+	//
+	transaction.pre_validation_calculations_parallelizable(publickey);
+	////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	// REMOVE ONCE NETWORK CAN PASS ROUTING SIGS //
+	/////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+	/////////////////////////////////////////////////////////
+
+
         let routing_work_available_for_me =
             transaction.get_routing_work_for_publickey(self.mempool_publickey);
-
-
-println!("mempool pubkey is: {:?}", self.mempool_publickey);
-if transaction.get_path().len() > 0 {
-println!("hop 1 is: {:?}", transaction.get_path()[0].get_to());
-}
 
         //println!("total fees in tx: {}", transaction.get_total_fees());
         //println!("routing paths: {:?}", transaction.get_path());
@@ -109,7 +137,6 @@ println!("hop 1 is: {:?}", transaction.get_path()[0].get_to());
             return AddTransactionResult::Exists;
         } else {
             self.transactions.push(transaction);
-println!("routing work increasing: ");
             self.routing_work_in_mempool += routing_work_available_for_me;
             return AddTransactionResult::Accepted;
         }
@@ -354,7 +381,7 @@ pub async fn run(
                     }
                     SaitoMessage::MempoolNewTransaction { transaction } => {
                         let mut mempool = mempool_lock.write().await;
-                        mempool.add_transaction(transaction);
+                        mempool.add_transaction(transaction).await;
                     },
                     SaitoMessage::MinerNewGoldenTicket { ticket : golden_ticket } => {
                         let mut mempool = mempool_lock.write().await;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -91,6 +91,12 @@ impl Mempool {
         let routing_work_available_for_me =
             transaction.get_routing_work_for_publickey(self.mempool_publickey);
 
+
+println!("mempool pubkey is: {:?}", self.mempool_publickey);
+if transaction.get_path().len() > 0 {
+println!("hop 1 is: {:?}", transaction.get_path()[0].get_to());
+}
+
         //println!("total fees in tx: {}", transaction.get_total_fees());
         //println!("routing paths: {:?}", transaction.get_path());
         //println!("routing work for me in this tx: {}", routing_work_available_for_me);
@@ -103,7 +109,7 @@ impl Mempool {
             return AddTransactionResult::Exists;
         } else {
             self.transactions.push(transaction);
-println!("routing work increasing!");
+println!("routing work increasing: ");
             self.routing_work_in_mempool += routing_work_available_for_me;
             return AddTransactionResult::Accepted;
         }

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -167,11 +167,10 @@ impl Mempool {
     ///
     /// Calculates the work available in mempool to produce a block
     ///
-    pub async fn calculate_work_available(&self) -> u64 {
+    pub fn calculate_work_available(&self) -> u64 {
         if self.routing_work_in_mempool > 0 {
             return self.routing_work_in_mempool;
         }
-
         return 0;
     }
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -103,6 +103,7 @@ impl Mempool {
             return AddTransactionResult::Exists;
         } else {
             self.transactions.push(transaction);
+println!("routing work increasing!");
             self.routing_work_in_mempool += routing_work_available_for_me;
             return AddTransactionResult::Accepted;
         }

--- a/src/network.rs
+++ b/src/network.rs
@@ -32,7 +32,7 @@ pub async fn run(
         .and(warp::path("transactions"))
         .and(warp::path::end())
         .and(body::aggregate().map(move |body| {
-            let transaction = post_transaction(body);
+            let mut transaction = post_transaction(body);
             broadcast_channel_sender
                 .send(SaitoMessage::MempoolNewTransaction { transaction })
                 .unwrap();

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -14,6 +14,7 @@ pub const SLIP_SIZE: usize = 75;
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Hash, Eq, PartialEq, TryFromByte)]
 pub enum SlipType {
     Normal,
+    ATR,
     VipInput,
     VipOutput,
     MinerInput,
@@ -52,6 +53,7 @@ impl Slip {
             is_utxoset_key_set: false,
         }
     }
+
 
     pub fn validate(&self, utxoset: &AHashMap<SaitoUTXOSetKey, u64>) -> bool {
         if self.get_amount() > 0 {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -276,7 +276,7 @@ impl Transaction {
 
         let mut transaction = Transaction::new();
         let mut output_payment = output_slip_to_rebroadcast.get_amount() - with_fee;
-	if (output_payment < 0) { output_payment = 0; }
+	if output_payment < 0 { output_payment = 0; }
 
         transaction.set_transaction_type(TransactionType::ATR);
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -258,6 +258,8 @@ impl Transaction {
         transaction.add_input(input);
         transaction.add_output(output);
 
+println!("VIP going to: {:?}", to_publickey);
+
         transaction
     }
 
@@ -507,9 +509,7 @@ println!("work by hop: {:?}", work_by_hop);
         //
         // we set slip ordinals when signing
         //
-        println!("signing tx with {} outputs: ", self.get_outputs().len());
         for (i, output) in self.get_mut_outputs().iter_mut().enumerate() {
-            println!("updating slip ordinal: {}", i);
             output.set_slip_ordinal(i as u8);
         }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -383,22 +383,27 @@ impl Transaction {
 	let mut aggregate_routing_work: u64 = self.get_total_fees();
 	let mut routing_work_this_hop: u64 = aggregate_routing_work;
         let mut work_by_hop : Vec<u64> = vec![];
+	work_by_hop.push(aggregate_routing_work);
 
-	for i in 1..self.path.len() {
+	for _i in 1..self.path.len() {
 	    let new_routing_work_this_hop: u64  = routing_work_this_hop / 2;
 	    aggregate_routing_work += new_routing_work_this_hop;
+            routing_work_this_hop = new_routing_work_this_hop;
 	    work_by_hop.push(aggregate_routing_work);
 	}
+
+println!("{:?}", work_by_hop);
 
 	//
         //
         // find winning routing node
         //
         let x = U256::from_big_endian(&random_hash);
-        let y: u64 = 10_000_000_000;
-        let z = U256::from_big_endian(&y.to_be_bytes());
+        let z = U256::from_big_endian(&aggregate_routing_work.to_be_bytes());
         let (zy, _bolres) = x.overflowing_rem(z);
         let winning_routing_work_in_nolan = zy.low_u64();
+
+println!("wrwin: {}", winning_routing_work_in_nolan);
 
 	for i in 0.. work_by_hop.len() {
 	    if winning_routing_work_in_nolan <= work_by_hop[i] {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -581,7 +581,7 @@ println!("work by hop: {:?}", work_by_hop);
     pub fn pre_validation_calculations_cumulative_work(&mut self, cumulative_work: u64) -> u64 {
         return cumulative_work + self.routing_work_for_creator;
     }
-    pub fn pre_validation_calculations_parallelizable(&mut self) -> bool {
+    pub fn pre_validation_calculations_parallelizable(&mut self, creator_publickey : SaitoPublicKey) -> bool {
         //
         // and save the hash_for_signature so we can use it later...
         //
@@ -627,11 +627,11 @@ println!("work by hop: {:?}", work_by_hop);
             self.total_fees = nolan_in - nolan_out;
         }
 
-	      //
-	      // we also need to know how much routing work exists and is available
-	      // for the block producer, to ensure that they have met the conditions
-	      // required by the burn fee for block production.
-	      //
+        //
+        // we also need to know how much routing work exists and is available
+        // for the block producer, to ensure that they have met the conditions
+        // required by the burn fee for block production.
+        //
         self.routing_work_for_creator = self.get_routing_work_for_publickey(creator_publickey);
 
         true


### PR DESCRIPTION
Includes some initial support for automatic transaction rebroadcasting.

We are not adding the ATR transactions to the block or validating them. But we are calculating them based on the assumption of a 2 block EPOCH. So this is scaffold code. What remains is basically to decide how to store the ATR transactions in the block so that we can have a fast and optimized sweep through the transaction set.

This PR also includes some updates to the spammer code that gets the transactions it is producing using Saito tokens owned by the wallet. And adds routing hops to them on receipt in the mempool so that we can calculate / test the routing work-related functions as needed.

I think this is ready for merge. The critical parts are largely contained to the Block.rs function that generates consensus data. And it fixes a number of bugs introduced by our merging of previous pull requests from different branches yesterday.