### PR TITLE
Sequential refactor generate metadata refactor

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,5 @@
+Casual list of suggestions on improvements:
+
+ - routing hops currently contain two publickeys and one signature. we can remove "from" because it is contextually available (from the sender of the first transaction, and then the *to* field. We should also be able to reduce the signatures by switching to a different/commutive signature. This would magnificently remove the size of our transactions and shrink blocksize as well.
+
+

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -60,8 +60,10 @@ pub async fn main() -> saito_rust::Result<()> {
                 // sign ...
                 transaction.sign(privatekey);
 
-		// make sure we know fees etc.
-		transaction.pre_validation_calculations_parallelizable(publickey);
+		// add some test hops ...
+        	transaction.add_hop_to_path(wallet_lock.clone(), publickey).await;
+        	transaction.add_hop_to_path(wallet_lock.clone(), publickey).await;
+
                 transactions.push(transaction);
 
 	    }

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -1,8 +1,5 @@
 use saito_rust::{
-    blockchain::Blockchain,
-    mempool::Mempool,
-    miner::Miner,
-    transaction::Transaction,
+    blockchain::Blockchain, mempool::Mempool, miner::Miner, transaction::Transaction,
     wallet::Wallet,
 };
 
@@ -44,12 +41,12 @@ pub async fn main() -> saito_rust::Result<()> {
         let client = reqwest::Client::new();
         // sleep(Duration::from_millis(5000));
         loop {
-
             let mut transactions: Vec<Transaction> = vec![];
 
-	    for _i in 0..txs_to_generate {
-
-                let mut transaction = Transaction::generate_transaction(wallet_lock.clone(), publickey, 5000, 5000).await;
+            for _i in 0..txs_to_generate {
+                let mut transaction =
+                    Transaction::generate_transaction(wallet_lock.clone(), publickey, 5000, 5000)
+                        .await;
                 transaction.set_message(
                     (0..bytes_per_tx)
                         .into_par_iter()
@@ -60,13 +57,16 @@ pub async fn main() -> saito_rust::Result<()> {
                 // sign ...
                 transaction.sign(privatekey);
 
-		// add some test hops ...
-        	transaction.add_hop_to_path(wallet_lock.clone(), publickey).await;
-        	transaction.add_hop_to_path(wallet_lock.clone(), publickey).await;
+                // add some test hops ...
+                transaction
+                    .add_hop_to_path(wallet_lock.clone(), publickey)
+                    .await;
+                transaction
+                    .add_hop_to_path(wallet_lock.clone(), publickey)
+                    .await;
 
                 transactions.push(transaction);
-
-	    }
+            }
 
             for mut tx in transactions {
                 let bytes: Vec<u8> = tx.serialize_for_net();
@@ -132,5 +132,3 @@ pub async fn run(
 
     Ok(())
 }
-
-

--- a/src/block.rs
+++ b/src/block.rs
@@ -497,7 +497,6 @@ impl Block {
  
            // fee transaction
             if !transaction.is_fee_transaction() {
-println!("this transaction has fees of: {}", transaction.get_total_fees());
                 total_fees += transaction.get_total_fees();
             } else {
                 ft_num += 1;
@@ -1107,7 +1106,6 @@ println!("now done cumulative work calculations...");
         }
 
         let block_merkle_root = block.generate_merkle_root();
-        println!("setting merkle root as: {:?}", block_merkle_root);
         block.set_merkle_root(block_merkle_root);
 
         let block_hash = block.generate_hash();

--- a/src/block.rs
+++ b/src/block.rs
@@ -579,10 +579,6 @@ impl Block {
                 //
                 // calculate miner and router payments
                 //
-                // TODO - REMOVE  - temporary to create additional tokens so we have circulating fees
-                //
-                total_fees += 10000;
-                //
                 let miner_payment = total_fees / 2;
                 let router_payment = total_fees - miner_payment;
 
@@ -764,8 +760,6 @@ println!("WE HAVE A TX TO PRUNE / REBROADCAST!");
                 _ => {}
             };
         }
-
-println!("now done cumulative work calculations...");
 
         self.set_has_fee_transaction(has_fee_transaction);
         self.set_has_golden_ticket(has_golden_ticket);

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -416,7 +416,7 @@ impl Blockchain {
         //
         {
             let block = self.blocks.get_mut(&new_chain[current_wind_index]).unwrap();
-            block.pre_validation_calculations();
+            block.generate_metadata();
         }
 
         let block = self.blocks.get(&new_chain[current_wind_index]).unwrap();

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -3,6 +3,14 @@ use crate::wallet::Wallet;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use std::convert::{TryFrom, TryInto};
+
+//
+// TODO - we can reduce the size by eliminating the FROM record if
+// the portions of the code that check the routing work start with
+// the sender of the transaction. This would be a good optimization
+//
+pub const HOP_SIZE: usize = 130;
 
 #[serde_with::serde_as]
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -62,6 +70,33 @@ impl Hop {
     pub fn set_sig(&mut self, sig: SaitoSignature) {
         self.sig = sig
     }
+
+
+    pub fn deserialize_from_net(bytes: Vec<u8>) -> Hop {
+
+        let from: SaitoPublicKey = bytes[..33].try_into().unwrap();
+        let to: SaitoPublicKey = bytes[33..66].try_into().unwrap();
+        let sig: SaitoSignature = bytes[66..130].try_into().unwrap();
+
+println!("from: {:?}", from);
+println!("to: {:?}", to);
+
+	let mut hop = Hop::new();
+        hop.set_from(from);
+        hop.set_to(to);
+        hop.set_sig(sig);
+
+        hop
+    }
+
+    pub fn serialize_for_net(&self) -> Vec<u8> {
+        let mut vbytes: Vec<u8> = vec![];
+        vbytes.extend(&self.get_from());
+        vbytes.extend(&self.get_to());
+        vbytes.extend(&self.get_sig());
+        vbytes
+    }
+
 }
 
 #[cfg(test)]

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -78,9 +78,6 @@ impl Hop {
         let to: SaitoPublicKey = bytes[33..66].try_into().unwrap();
         let sig: SaitoSignature = bytes[66..130].try_into().unwrap();
 
-println!("from: {:?}", from);
-println!("to: {:?}", to);
-
 	let mut hop = Hop::new();
         hop.set_from(from);
         hop.set_to(to);

--- a/src/hop.rs
+++ b/src/hop.rs
@@ -1,9 +1,9 @@
 use crate::crypto::{sign, SaitoHash, SaitoPublicKey, SaitoSignature};
 use crate::wallet::Wallet;
 use serde::{Deserialize, Serialize};
+use std::convert::{TryFrom, TryInto};
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use std::convert::{TryFrom, TryInto};
 
 //
 // TODO - we can reduce the size by eliminating the FROM record if
@@ -71,14 +71,12 @@ impl Hop {
         self.sig = sig
     }
 
-
     pub fn deserialize_from_net(bytes: Vec<u8>) -> Hop {
-
         let from: SaitoPublicKey = bytes[..33].try_into().unwrap();
         let to: SaitoPublicKey = bytes[33..66].try_into().unwrap();
         let sig: SaitoSignature = bytes[66..130].try_into().unwrap();
 
-	let mut hop = Hop::new();
+        let mut hop = Hop::new();
         hop.set_from(from);
         hop.set_to(to);
         hop.set_sig(sig);
@@ -93,7 +91,6 @@ impl Hop {
         vbytes.extend(&self.get_sig());
         vbytes
     }
-
 }
 
 #[cfg(test)]

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -1,6 +1,13 @@
 use crate::{
-    block::Block, blockchain::Blockchain, burnfee::BurnFee, consensus::SaitoMessage, crypto::{SaitoPrivateKey, SaitoPublicKey},
-    golden_ticket::GoldenTicket, time::create_timestamp, transaction::Transaction, wallet::Wallet,
+    block::Block,
+    blockchain::Blockchain,
+    burnfee::BurnFee,
+    consensus::SaitoMessage,
+    crypto::{SaitoPrivateKey, SaitoPublicKey},
+    golden_ticket::GoldenTicket,
+    time::create_timestamp,
+    transaction::Transaction,
+    wallet::Wallet,
 };
 use std::{collections::HashMap, collections::VecDeque, sync::Arc, thread::sleep, time::Duration};
 use tokio::sync::{broadcast, mpsc, RwLock};
@@ -89,41 +96,40 @@ impl Mempool {
     pub async fn add_transaction(&mut self, mut transaction: Transaction) -> AddTransactionResult {
         let tx_sig_to_insert = transaction.get_signature();
 
-	/////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-	// TODO -- this is just testing -- remove async too    // 
-	/////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-	let publickey;
-	{
-	    let wallet = self.wallet_lock.read().await;
-	    publickey = wallet.get_publickey();
-	}
-/***
+        /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        // TODO -- this is just testing -- remove async too    //
+        /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        let publickey;
+        {
+            let wallet = self.wallet_lock.read().await;
+            publickey = wallet.get_publickey();
+        }
+        /***
 
-        transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
-        transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
-	//
-	// note that this calculates the total fees, so needs to 
-	// be handled well. Stephen may have some ideas on how we
-	// can better name these functions. what this is really 
-	// doing is filling in the total fee amounts so that we 
-	// can calculate the routing work below to know how much
-	// this contributes to our mempool.
-	//
-***/
-	transaction.generate_metadata(publickey);
+                transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
+                transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
+            //
+            // note that this calculates the total fees, so needs to
+            // be handled well. Stephen may have some ideas on how we
+            // can better name these functions. what this is really
+            // doing is filling in the total fee amounts so that we
+            // can calculate the routing work below to know how much
+            // this contributes to our mempool.
+            //
+        ***/
+        transaction.generate_metadata(publickey);
 
-	////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-	// REMOVE ONCE NETWORK CAN PASS ROUTING SIGS //
-	/////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-	/////////////////////////////////////////////////////////
-
+        ////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        // REMOVE ONCE NETWORK CAN PASS ROUTING SIGS //
+        /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////
 
         let routing_work_available_for_me =
             transaction.get_routing_work_for_publickey(self.mempool_publickey);
@@ -394,7 +400,6 @@ pub async fn run(
                 }
             }
         }
-
     }
 }
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -101,6 +101,7 @@ impl Mempool {
 	    let wallet = self.wallet_lock.read().await;
 	    publickey = wallet.get_publickey();
 	}
+/***
 
         transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
         transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
@@ -112,7 +113,9 @@ impl Mempool {
 	// can calculate the routing work below to know how much
 	// this contributes to our mempool.
 	//
-	transaction.pre_validation_calculations_parallelizable(publickey);
+***/
+	transaction.generate_metadata(publickey);
+
 	////////////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -236,7 +236,7 @@ mod tests {
     #[test]
     fn slip_serialize_for_signature_test() {
         let slip = Slip::new();
-        assert_eq!(slip.serialize_for_signature(), vec![0; 78]);
+        assert_eq!(slip.serialize_input_for_signature(), vec![0; 78]);
     }
 
     #[test]

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -54,7 +54,6 @@ impl Slip {
         }
     }
 
-
     pub fn validate(&self, utxoset: &AHashMap<SaitoUTXOSetKey, u64>) -> bool {
         if self.get_amount() > 0 {
             let mut _return_value = false;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -889,9 +889,7 @@ mod tests {
         mock_tx.set_signature([1; 64]);
         let serialized_tx = mock_tx.serialize_for_net();
 
-println!("SERIALIZED: {:?}", mock_tx);
         let deserialized_tx = Transaction::deserialize_from_net(serialized_tx);
-println!("DESERIALIZED: {:?}", deserialized_tx);
         assert_eq!(mock_tx, deserialized_tx);
     }
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -275,8 +275,10 @@ impl Transaction {
     ) -> Transaction {
 
         let mut transaction = Transaction::new();
-        let mut output_payment = output_slip_to_rebroadcast.get_amount() - with_fee;
-	if output_payment < 0 { output_payment = 0; }
+	let mut output_payment = 0;
+    	if output_slip_to_rebroadcast.get_amount() > with_fee {
+            output_payment = output_slip_to_rebroadcast.get_amount() - with_fee;
+	}
 
         transaction.set_transaction_type(TransactionType::ATR);
 
@@ -369,6 +371,10 @@ impl Transaction {
         self.transaction_type == TransactionType::Fee
     }
 
+    pub fn is_atr_transaction(&self) -> bool {
+        self.transaction_type == TransactionType::ATR
+    }
+
     pub fn is_golden_ticket(&self) -> bool {
         self.transaction_type == TransactionType::GoldenTicket
     }
@@ -425,13 +431,14 @@ impl Transaction {
 	// definition. this is the edge-case where sending a tx
 	// can make you money.
 	//
-	if self.path.len() == 0 {
+	if self.path.len() == 0 || self.get_total_fees() == 0 {
 	    if self.inputs.len() > 0 {
 		return self.inputs[0].get_publickey();
 	    } else {
 		return [0; 33];
 	    }
 	}
+
 
 	//
 	// if we have a routing path, we calculate the total amount

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -258,8 +258,6 @@ impl Transaction {
         transaction.add_input(input);
         transaction.add_output(output);
 
-println!("VIP going to: {:?}", to_publickey);
-
         transaction
     }
 
@@ -661,9 +659,7 @@ println!("work by hop: {:?}", work_by_hop);
     // calculate cumulative fee share in block
     //
     pub fn generate_metadata_cumulative_fees(&mut self, cumulative_fees: u64) -> u64 {
-println!("1 {} {}", cumulative_fees, self.total_fees);
         self.cumulative_fees = cumulative_fees + self.total_fees;
-println!("2");
         self.cumulative_fees
     }
     //
@@ -878,7 +874,13 @@ mod tests {
     fn serialize_for_net_test() {
         let mock_input = Slip::new();
         let mock_output = Slip::new();
+	let mut mock_hop = Hop::new();
+	    mock_hop.set_from([0; 33]);
+	    mock_hop.set_to([0; 33]);
+	    mock_hop.set_sig([0; 64]);
         let mut mock_tx = Transaction::new();
+	let mut mock_path: Vec<Hop> = vec![];
+	    mock_path.push(mock_hop);
 	let ctimestamp = create_timestamp();
 	
         mock_tx.set_timestamp(ctimestamp);
@@ -887,6 +889,9 @@ mod tests {
         mock_tx.set_message(vec![104, 101, 108, 108, 111]);
         mock_tx.set_transaction_type(TransactionType::Normal);
         mock_tx.set_signature([1; 64]);
+        mock_tx.set_path(mock_path);
+
+
         let serialized_tx = mock_tx.serialize_for_net();
 
         let deserialized_tx = Transaction::deserialize_from_net(serialized_tx);


### PR DESCRIPTION
A lot of confusing function names have been replaced with the GENERATE_METADATA class of functions. All functions with this name or prefix handle the preparation of data needed to produce or validate blocks, i.e.:

block.generate_metadata()
transaction.generate_metadata()
transaction.generate_metadata_hashes()
transaction.generate_metadata_fees_and_slips()
etc. 

The serialization / deserialization code has been updated for transactions (and blocks) so that we include routing paths (self.path). An additional class serialize_for_net_with_hop(hop : Hop) can be used to serialize with the additional hop of the node to which we are sending the transaction -- if this approach works we can do something similar with block.

ATR transaction creation and validation code is more fleshed out, although not entirely working yet. Making this pull request so that we can get feedback or criticism of the above changes, and make any fixes. I think the structure of the code is getting cleaner and hopefully more intuitive, although we're still a bit messy with "let cv = block.generate_data_to_validate(blockchain)".