### PR TITLE
Sequential refactor wind chain async block load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
 
 [[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1526,7 @@ name = "saito_rust"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "async-recursion",
  "base58",
  "bigint",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/bin/spammer.rs"
 
 [dependencies]
 ahash = "0.7.4"
+async-recursion = "0.3.2"
 bigint = "4.4.3"
 enum-variant-count-derive = { path = "enum-variant-count-derive" }
 rayon = "1.5"

--- a/src/block.rs
+++ b/src/block.rs
@@ -1028,8 +1028,8 @@ impl Block {
             //
             fee_transaction.generate_metadata(self.get_creator());
 
-            println!("CV: {:?}", fee_transaction);
-            println!("BLK: {:?}", self.transactions[ft_idx]);
+            //println!("CV: {:?}", fee_transaction);
+            //println!("BLK: {:?}", self.transactions[ft_idx]);
 
             let hash1 = hash(&fee_transaction.serialize_for_signature());
             let hash2 = hash(&self.transactions[ft_idx].serialize_for_signature());

--- a/src/block.rs
+++ b/src/block.rs
@@ -603,6 +603,7 @@ impl Block {
                                 //
                                 // TODO - floating fee based on previous block average
                                 //
+println!("GENERATING REBROADCAST TX: {:?}", transaction.get_transaction_type());
                                 let rebroadcast_transaction =
                                     Transaction::generate_rebroadcast_transaction(
                                         &transaction,
@@ -1090,6 +1091,7 @@ impl Block {
         //
         // and if our transactions are valid, so is the block...
         //
+        println!(" ... are txs valid: {}", transactions_valid);
         transactions_valid
     }
 

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -13,7 +13,7 @@ use tokio::sync::{broadcast, mpsc, RwLock};
 
 use ahash::AHashMap;
 
-pub const GENESIS_PERIOD: u64 = 2;
+pub const GENESIS_PERIOD: u64 = 6;
 
 pub fn bit_pack(top: u32, bottom: u32) -> u64 {
     ((top as u64) << 32) + (bottom as u64)
@@ -511,6 +511,7 @@ impl Blockchain {
             // will know it has rewound the old chain successfully instead of
             // successfully added the new chain.
             //
+println!("this block does not validate!");
             if current_wind_index == new_chain.len() - 1 {
                 //
                 // this is the first block we have tried to add
@@ -641,6 +642,8 @@ impl Blockchain {
         //
 	let latest_block_id = self.get_latest_block_id();
         if latest_block_id >= ((GENESIS_PERIOD * 2) + 1) {
+
+println!("PRUNING data from the blockchain and updating the genesis period...");
 
             let purge_bid = latest_block_id - (GENESIS_PERIOD * 2);
             self.genesis_block_id = latest_block_id - GENESIS_PERIOD;

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -143,11 +143,14 @@ impl BlockRing {
         block_hash: SaitoHash,
     ) -> bool {
         let insert_pos = block_id % RING_BUFFER_LENGTH;
-println!("contains block hash at block id... {:?} {}", block_hash, insert_pos);
-println!("insert pos is: {} {}", insert_pos, GENESIS_PERIOD);
+        println!(
+            "contains block hash at block id... {:?} {}",
+            block_hash, insert_pos
+        );
+        println!("insert pos is: {} {}", insert_pos, GENESIS_PERIOD);
         let res = self.block_ring[(insert_pos as usize)].contains_block_hash(block_hash);
-println!("ontains block hash at block id 2...");
-	return res;
+        println!("ontains block hash at block id 2...");
+        return res;
     }
 
     pub fn add_block(&mut self, block: &Block) {
@@ -168,15 +171,13 @@ println!("ontains block hash at block id 2...");
             //
             if let Some(block_ring_lc_pos) = self.block_ring_lc_pos {
                 if block_ring_lc_pos == insert_pos as usize {
+                    let previous_block_idx;
 
-		    let previous_block_idx;
-
-		    if block_ring_lc_pos > 0 {
-                      previous_block_idx = block_ring_lc_pos - 1;
-		    } else {
-                      previous_block_idx = RING_BUFFER_LENGTH as usize - 1;
-		    }
-
+                    if block_ring_lc_pos > 0 {
+                        previous_block_idx = block_ring_lc_pos - 1;
+                    } else {
+                        previous_block_idx = RING_BUFFER_LENGTH as usize - 1;
+                    }
 
                     // reset to lc_pos to unknown
                     self.block_ring_lc_pos = None;

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -168,7 +168,15 @@ println!("ontains block hash at block id 2...");
             //
             if let Some(block_ring_lc_pos) = self.block_ring_lc_pos {
                 if block_ring_lc_pos == insert_pos as usize {
-                    let previous_block_idx = block_ring_lc_pos - 1;
+
+		    let previous_block_idx;
+
+		    if block_ring_lc_pos > 0 {
+                      previous_block_idx = block_ring_lc_pos - 1;
+		    } else {
+                      previous_block_idx = RING_BUFFER_LENGTH as usize - 1;
+		    }
+
 
                     // reset to lc_pos to unknown
                     self.block_ring_lc_pos = None;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -94,49 +94,25 @@ impl Mempool {
     // this handles any transactions broadcast on the same system. it receives the transaction
     // directly and so does not validate against the UTXOset etc.
     pub async fn add_transaction(&mut self, mut transaction: Transaction) -> AddTransactionResult {
+
         let tx_sig_to_insert = transaction.get_signature();
 
-        /////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
-        // TODO -- this is just testing -- remove async too    //
-        /////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
+	//
+	// this assigns the amount of routing work that this transaction 
+	// contains to us, which is why we need to provide our publickey
+	// so that we can calculate routing work.
+	//
         let publickey;
         {
             let wallet = self.wallet_lock.read().await;
             publickey = wallet.get_publickey();
         }
-        /***
-
-                transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
-                transaction.add_hop_to_path(self.wallet_lock.clone(), publickey).await;
-            //
-            // note that this calculates the total fees, so needs to
-            // be handled well. Stephen may have some ideas on how we
-            // can better name these functions. what this is really
-            // doing is filling in the total fee amounts so that we
-            // can calculate the routing work below to know how much
-            // this contributes to our mempool.
-            //
-        ***/
         transaction.generate_metadata(publickey);
-
-        ////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
-        // REMOVE ONCE NETWORK CAN PASS ROUTING SIGS //
-        /////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
-        /////////////////////////////////////////////////////////
 
         let routing_work_available_for_me =
             transaction.get_routing_work_for_publickey(self.mempool_publickey);
 
-        //println!("total fees in tx: {}", transaction.get_total_fees());
-        //println!("routing paths: {:?}", transaction.get_path());
-        //println!("routing work for me in this tx: {}", routing_work_available_for_me);
+//        println!("adding tx with routing work for me: {}", routing_work_available_for_me);
 
         if self
             .transactions

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -60,11 +60,20 @@ impl Slip {
     pub fn validate(&self, utxoset: &UtxoSet) -> bool {
         if self.get_amount() > 0 {
             match utxoset.get(&self.utxoset_key) {
-                Some(value) => *value == 1,
-                None => false,
+                Some(value) => {
+		    if *value==1 {
+		        return true;
+		    } else {
+			return false;
+		    }
+	        }
+                None => {
+println!("value is returned false: {:?} ordinal {} and amount {}", self.utxoset_key, self.get_slip_ordinal(), self.get_amount());
+		    return false;
+            	}
             }
         } else {
-            true
+            return true;
         }
     }
 
@@ -75,6 +84,9 @@ impl Slip {
         slip_value: u64,
     ) {
         if self.get_amount() > 0 {
+//println!("inserting into utxoset: {:?} value {}", self.utxoset_key, slip_value);
+//println!("slip_ordinal: {}", self.get_slip_ordinal());
+//println!("slip_amount: {}", self.get_amount());
             utxoset.entry(self.utxoset_key).or_insert(slip_value);
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -26,6 +26,8 @@ impl Storage {
         filename.push_str(&hex::encode(&block.generate_hash()));
         filename.push_str(&".sai");
 
+//println!("trying to write to disk: {}", filename);
+
         let mut buffer = File::create(filename).unwrap();
         let byte_array: Vec<u8> = block.serialize_for_net();
         buffer.write_all(&byte_array[..]).unwrap();

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -525,6 +525,7 @@ impl Transaction {
     }
 
     pub fn sign(&mut self, privatekey: SaitoPrivateKey) {
+
         //
         // we set slip ordinals when signing
         //
@@ -857,17 +858,35 @@ impl Transaction {
         //
         // fee transactions
         //
-        if transaction_type != TransactionType::Fee {
-
+        if transaction_type == TransactionType::Fee {
+//println!("Fee Transaction");
             // signed by block creator ?
         }
 
         //
         // atr transactions
         //
-        if transaction_type != TransactionType::ATR {
+        if transaction_type == TransactionType::ATR {
+//println!("ATR Transaction");
 
             // signed by block creator ?
+        }
+
+
+        //
+        // normal transactions
+        //
+        if transaction_type == TransactionType::Normal {
+//println!("Normal Transaction");
+
+        }
+
+        //
+        // golden ticket transactions
+        //
+        if transaction_type == TransactionType::GoldenTicket {
+//println!("Golden Ticket Transaction");
+
         }
 
         //
@@ -878,7 +897,8 @@ impl Transaction {
         // project. they carried us and we're going to carry them. thanks
         // for the faith and support.
         //
-        if transaction_type != TransactionType::Vip {
+        if transaction_type == TransactionType::Vip {
+//println!("VIP Transaction");
 
             // we should validate that VIP transactions are signed by the
             // publickey associated with the Saito project.
@@ -904,8 +924,11 @@ impl Transaction {
         // tokens it will pass this check, which is conducted inside
         // the slip-level validation logic.
         //
-        self.inputs.par_iter().all(|input| input.validate(utxoset))
+        let inputs_validate = self.inputs.par_iter().all(|input| input.validate(utxoset));
+
+	inputs_validate
     }
+
 }
 
 #[cfg(test)]

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -97,6 +97,7 @@ impl Wallet {
                     input.set_publickey(my_publickey);
                     input.set_amount(slip.get_amount());
                     input.set_uuid(slip.get_uuid());
+                    input.set_slip_ordinal(slip.get_slip_ordinal());
                     inputs.push(input);
 
                     slip.set_spent(true);


### PR DESCRIPTION
Some significant changes:

wind and unwind chain are now ASYNC.

we do this so that we can potentially load blocks from disk instead of just fetching from the blockchain.blocks index when re-writing the chain.

minor fix to the way slip validation is handled

ATR improved, with the GENESIS_PERIOD now managed explicitly by blockchain.

