### PR TITLE
Mempool testing

### DIFF
--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -5,6 +5,7 @@ TODO: Fill in these docs
 
 */
 use saito_rust::networking::peer::PeersDB;
+use saito_rust::time::SystemTimestampGenerator;
 use saito_rust::{
     blockchain::Blockchain, mempool::Mempool, miner::Miner, networking::network::Network,
     transaction::Transaction, util::format_url_string, wallet::Wallet,
@@ -197,7 +198,7 @@ pub async fn run(
             mempool_lock.clone(),
             blockchain_lock.clone(),
             broadcast_channel_sender.clone(),
-            broadcast_channel_receiver
+            broadcast_channel_receiver,
         ) => {
             if let Err(err) = res {
                 eprintln!("{:?}", err)

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1158,7 +1158,7 @@ mod tests {
             publickey = wallet.get_public_key();
         }
 
-        for i in 0..4 {
+        for i in 0..3 {
             transactions = vec![];
             let block: Block;
 

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -137,6 +137,8 @@ impl Blockchain {
         //
         if !self.blocks.contains_key(&block_hash) {
             self.blocks.insert(block_hash, block);
+        } else {
+            println!("BLOCK IS ALREAYD IN THE BLOCKCHAIN, WHY ARE WE ADDING IT?????");
         }
 
         // println!(" ... start shared ancestor hunt: {:?}", create_timestamp());
@@ -299,7 +301,7 @@ impl Blockchain {
         {
             let block = self.get_mut_block(block_hash).await;
             block_id = block.get_id();
-            if save_to_disk {
+            if save_to_disk || true {
                 Storage::write_block_to_disk(block);
             }
 
@@ -830,7 +832,7 @@ impl Blockchain {
         //
         {
             let pblock = self.blocks.get(&delete_block_hash).unwrap();
-            let pblock_filename = pblock.get_filename().clone();
+            let pblock_filename = Storage::generate_block_filename(pblock);
 
             //
             // remove slips from wallet
@@ -1064,7 +1066,7 @@ mod tests {
                 block_copy.get_previous_block_hash(),
                 latest_block.get_previous_block_hash()
             );
-	
+
             let prev_block = blockchain.get_block_sync(&latest_block.get_previous_block_hash());
             assert!(prev_block.is_none());
         }
@@ -1145,6 +1147,7 @@ mod tests {
         let mut transactions: Vec<Transaction>;
         let mut last_block_hash: SaitoHash = [0; 32];
         let mut last_block_difficulty: u64 = 0;
+        let mut prev_block_hash: SaitoHash = [0; 32];
         let publickey;
 
         let mut test_block_hash: SaitoHash;
@@ -1231,6 +1234,17 @@ mod tests {
                 blockchain.add_block(block, false).await;
                 assert_eq!(test_block_hash, blockchain.get_latest_block_hash());
                 assert_eq!(test_block_id, blockchain.get_latest_block_id());
+                assert_eq!(
+                    prev_block_hash,
+                    blockchain
+                        .get_latest_block()
+                        .unwrap()
+                        .get_previous_block_hash()
+                );
+                if test_block_id > 1 {
+                    assert!(blockchain.get_block_sync(&prev_block_hash).is_some());
+                }
+                prev_block_hash = test_block_hash;
             }
         }
     }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -4,6 +4,7 @@ use crate::miner::Miner;
 use crate::networking::network::Network;
 use crate::networking::peer::PeersDB;
 use crate::storage::Storage;
+use crate::time::SystemTimestampGenerator;
 use crate::wallet::Wallet;
 use crate::{blockchain::Blockchain, mempool::Mempool, transaction::Transaction};
 use clap::{App, Arg};
@@ -117,6 +118,7 @@ impl Consensus {
         // broadcast cross-system messages. See SaitoMessage ENUM above
         // for information on cross-system notifications.
         //
+        
         let wallet_lock = Arc::new(RwLock::new(Wallet::new(key_path, password)));
         let peers_db_lock = Arc::new(RwLock::new(PeersDB::new()));
 
@@ -148,7 +150,7 @@ impl Consensus {
                 mempool_lock.clone(),
                 blockchain_lock.clone(),
                 broadcast_channel_sender.clone(),
-                broadcast_channel_receiver
+                broadcast_channel_receiver,
             ) => {
                 if let Err(err) = res {
                     eprintln!("{:?}", err)

--- a/src/networking/network.rs
+++ b/src/networking/network.rs
@@ -380,7 +380,7 @@ mod tests {
 
         let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
-        let (blockchain_lock, block_hashes) =
+        let (blockchain_lock, _block_hashes) =
             make_mock_blockchain(wallet_lock.clone(), 1 as u64).await;
 
         let mut settings = config::Config::default();
@@ -403,7 +403,7 @@ mod tests {
         //
         // first confirm the whole blockchain is received when sent zeroed block hash
         //
-        let mut request_blockchain_message = RequestBlockchainMessage::new(0, [0; 32], [42; 32]);
+        let request_blockchain_message = RequestBlockchainMessage::new(0, [0; 32], [42; 32]);
 
         let api_message = APIMessage::new("REQCHAIN", 0, request_blockchain_message.serialize());
         let serialized_api_message = api_message.serialize();
@@ -411,7 +411,7 @@ mod tests {
         let _socket_resp = ws_client
             .send(Message::binary(serialized_api_message))
             .await;
-        let resp = ws_client.recv().await.unwrap();
+        let _resp = ws_client.recv().await.unwrap();
         // let command = String::from_utf8_lossy(&resp.as_bytes()[0..8]);
         // let index: u32 = u32::from_be_bytes(resp.as_bytes()[8..12].try_into().unwrap());
         // let msg = resp.as_bytes()[12..].to_vec();

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -34,15 +34,17 @@ impl Storage {
         buffer.write_all(&data[..]).unwrap();
     }
 
-    pub fn write_block_to_disk(block: &mut Block) {
+    pub fn generate_block_filename(block: &Block) -> String {
         let mut filename = String::from(BLOCKS_DIR_PATH).clone();
 
         filename.push_str(&hex::encode(block.get_timestamp().to_be_bytes()));
         filename.push_str(&String::from("-"));
         filename.push_str(&hex::encode(&block.get_hash()));
         filename.push_str(&".sai");
-
-        block.set_filename(filename.clone());
+        filename
+    }
+    pub fn write_block_to_disk(block: &mut Block) {
+        let filename = Storage::generate_block_filename(block);
 
         //println!("trying to write to disk: {}", filename);
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -67,3 +67,24 @@ impl TracingAccumulator {
         self.total
     }
 }
+
+
+pub trait Persistable {
+    fn save(&self);
+    fn load(filename: &str) -> Self;
+}
+
+pub trait TimestampGenerator {
+    fn get_timestamp(&mut self) -> u64 {
+        create_timestamp()
+    }
+}
+
+pub struct SystemTimestampGenerator {}
+impl TimestampGenerator for SystemTimestampGenerator {
+
+    // fn get_timestamp(&mut self) -> u64 {
+    //     create_timestamp()
+    // }
+}
+

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -149,7 +149,7 @@ impl Transaction {
 
         let available_balance = wallet.get_available_balance();
         let total_requested = with_payment + with_fee;
-        //println!("in generate transaction ab: {} and pr: {} and fr: {}", available_balance, with_payment, with_fee);
+        println!("in generate transaction ab: {} and pr: {} and fr: {}", available_balance, with_payment, with_fee);
 
         if available_balance >= total_requested {
             let mut transaction = Transaction::new();

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -130,7 +130,7 @@ impl Wallet {
                 self.delete_slip(input);
             }
             for output in tx.get_outputs() {
-                if output.get_amount() > 0 {
+                if output.get_amount() > 0 && output.get_publickey() == self.public_key {
                     self.add_slip(block, tx, output, block.get_lc());
                 }
             }


### PR DESCRIPTION
This does some minor refactoring to mempool to provide testable interfaces(moved some code into try_bundle_block and process_blocks functions). 

This also removes GenerateBlock, which seems to be a duplicate of TryBundleBlock.

This also adds a Trait TimestampGenerator which has a default impl which simply wraps the system timestamp(create_timestamp). use SystemTimestampGenerator to access this. It also adds a separate implementation of the trait called MockTimestampGenerator which can be used in test to pause/advance the timestamp. The idea is for this to be used in place nearly everywhere that we currently use create_timestamp(). This makes testing things like mempool and block validation much simpler.

This also adds some basic mempool tests which still need work. This was done to test hypotheses and make assertions related to the previous_block_hash issue.