### PR TITLE
fix: tests working with reverted wallet constructor

### DIFF
--- a/src/bin/saitocli.rs
+++ b/src/bin/saitocli.rs
@@ -167,7 +167,7 @@ pub async fn main() -> saito_rust::Result<()> {
         let password = matches.value_of("password");
 
         let mut wallet = Wallet::new();
-	wallet.load_keys(key_file, password);
+        wallet.load_keys(key_file, password);
 
         println!("public key : {}", hex::encode(wallet.get_publickey()));
         println!("private key : {}", hex::encode(wallet.get_privatekey()));

--- a/src/bin/saitocli.rs
+++ b/src/bin/saitocli.rs
@@ -166,7 +166,9 @@ pub async fn main() -> saito_rust::Result<()> {
         let key_file = matches.value_of("keyfile").unwrap();
         let password = matches.value_of("password");
 
-        let wallet = Wallet::new(key_file, password);
+        let mut wallet = Wallet::new();
+	wallet.load_keys(key_file, password);
+
         println!("public key : {}", hex::encode(wallet.get_publickey()));
         println!("private key : {}", hex::encode(wallet.get_privatekey()));
     }
@@ -223,7 +225,9 @@ pub async fn main() -> saito_rust::Result<()> {
         let key_file = matches.value_of("keyfile").unwrap();
         let password = matches.value_of("password");
 
-        let wallet = Wallet::new(key_file, password);
+        let mut wallet = Wallet::new();
+        wallet.load_keys(key_file, password);
+
         let filename: String = match matches.value_of("filename") {
             Some(filename) => String::from(filename),
             None => String::from("transaction.out"),

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -79,7 +79,11 @@ pub async fn main() -> saito_rust::Result<()> {
         None => 1024,
     };
 
-    let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+    let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+    {
+        let mut wallet = wallet_lock.write().await;
+	wallet.load_keys("test/testwallet", Some("asdf"));
+    }
     let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
 
     let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -82,7 +82,7 @@ pub async fn main() -> saito_rust::Result<()> {
     let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
     {
         let mut wallet = wallet_lock.write().await;
-	wallet.load_keys("test/testwallet", Some("asdf"));
+        wallet.load_keys("test/testwallet", Some("asdf"));
     }
     let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
 
@@ -117,7 +117,6 @@ pub async fn main() -> saito_rust::Result<()> {
         event!(Level::INFO, "{:?}", server_transaction_url);
 
         loop {
-
             let mut transactions: Vec<Transaction> = vec![];
 
             event!(Level::INFO, "TXS TO GENERATE: {:?}", txs_to_generate);
@@ -145,8 +144,7 @@ pub async fn main() -> saito_rust::Result<()> {
                     .add_hop_to_path(wallet_lock.clone(), publickey)
                     .await;
 
-
-//println!("TRANSACTION: {:?}", transaction);
+                //println!("TRANSACTION: {:?}", transaction);
 
                 transactions.push(transaction);
             }

--- a/src/block.rs
+++ b/src/block.rs
@@ -1959,7 +1959,8 @@ mod tests {
 
     #[test]
     fn block_sign_test() {
-        let wallet = Wallet::new("test/testwallet", Some("asdf"));
+        let mut wallet = Wallet::new();
+        wallet.load_keys("test/testwallet", Some("asdf"));
         let mut block = Block::new();
 
         block.sign(wallet.get_publickey(), wallet.get_privatekey());
@@ -2034,7 +2035,8 @@ mod tests {
     #[test]
     fn block_merkle_root_test() {
         let mut block = Block::new();
-        let wallet = Wallet::new("test/testwallet", Some("asdf"));
+        let mut wallet = Wallet::new();
+        wallet.load_keys("test/testwallet", Some("asdf"));
 
         let mut transactions = (0..5)
             .into_iter()
@@ -2053,7 +2055,8 @@ mod tests {
     #[tokio::test]
     async fn block_downgrade_test() {
         let mut block = Block::new();
-        let wallet = Wallet::new("test/testwallet", Some("asdf"));
+        let mut wallet = Wallet::new();
+        wallet.load_keys("test/testwallet", Some("asdf"));
         let mut transactions = (0..5)
             .into_iter()
             .map(|_| {
@@ -2075,7 +2078,7 @@ mod tests {
 
     #[tokio::test]
     async fn block_serialization_test() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::default()));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let test_manager = TestManager::new(blockchain_lock.clone(), wallet_lock.clone());
 

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1315,7 +1315,11 @@ mod tests {
 
     #[tokio::test]
     async fn add_blocks_test_1() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+            let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
 
@@ -1437,7 +1441,11 @@ mod tests {
     #[tokio::test]
     async fn produce_four_blocks_test() {
         // There... are... four blocks!
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+            let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let mut miner = Miner::new(wallet_lock.clone());
 

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -91,8 +91,8 @@ impl Blockchain {
         let block_id = block.get_id();
         let previous_block_hash = self.blockring.get_latest_block_hash();
 
-println!("blockring reports prev hash: {:?}", previous_block_hash);
-println!("block reports: {:?}", block.get_previous_block_hash());
+        println!("blockring reports prev hash: {:?}", previous_block_hash);
+        println!("block reports: {:?}", block.get_previous_block_hash());
 
         //
         // sanity checks
@@ -1316,10 +1316,10 @@ mod tests {
     #[tokio::test]
     async fn add_blocks_test_1() {
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
+        {
             let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
 
@@ -1442,10 +1442,10 @@ mod tests {
     async fn produce_four_blocks_test() {
         // There... are... four blocks!
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
+        {
             let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let mut miner = Miner::new(wallet_lock.clone());
 

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -371,7 +371,11 @@ mod test {
     #[tokio::test]
     async fn blockring_add_and_delete_block() {
         let mut blockring = BlockRing::new();
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+            let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
 

--- a/src/blockring.rs
+++ b/src/blockring.rs
@@ -358,10 +358,7 @@ mod test {
 
         blockring.on_chain_reorganization(mock_block.get_id(), mock_block.get_hash(), true);
         assert_eq!(0, blockring.get_longest_chain_block_id());
-        assert_eq!(
-            mock_block.get_hash(),
-            blockring.get_latest_block_hash()
-        );
+        assert_eq!(mock_block.get_hash(), blockring.get_latest_block_hash());
         assert_eq!(
             mock_block.get_hash(),
             blockring.get_longest_chain_block_hash_by_block_id(0)
@@ -372,10 +369,10 @@ mod test {
     async fn blockring_add_and_delete_block() {
         let mut blockring = BlockRing::new();
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
+        {
             let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -117,7 +117,11 @@ impl Consensus {
         // broadcast cross-system messages. See SaitoMessage ENUM above
         // for information on cross-system notifications.
         //
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new(key_path, password)));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+	    let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys(key_path, password);
+	}
 
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         // Load blocks from disk if configured

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -118,10 +118,10 @@ impl Consensus {
         // for information on cross-system notifications.
         //
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
-	    let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys(key_path, password);
-	}
+        {
+            let mut wallet = wallet_lock.write().await;
+            wallet.load_keys(key_path, password);
+        }
 
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         // Load blocks from disk if configured

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -29,7 +29,7 @@ pub fn generate_keys() -> (SaitoPublicKey, SaitoPrivateKey) {
     (public_key.serialize(), secret_bytes)
 }
 /// Create and return a keypair with  the given hex u8 array as the private key
-pub fn keys_from_slice(slice: &[u8]) -> (SaitoPublicKey, SaitoPrivateKey) {
+pub fn generate_keypair_from_privatekey(slice: &[u8]) -> (SaitoPublicKey, SaitoPrivateKey) {
     let secret_key = SecretKey::from_slice(slice).unwrap();
     let public_key = PublicKey::from_secret_key(&SECP256K1, &secret_key);
     let mut secret_bytes = [0u8; 32];

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -254,7 +254,10 @@ impl Mempool {
         let blockchain = blockchain_lock.read().await;
         let previous_block_hash = blockchain.get_latest_block_hash();
 
-println!("We are generating the block with this block hash: {:?}", blockchain.get_latest_block_hash());
+        println!(
+            "We are generating the block with this block hash: {:?}",
+            blockchain.get_latest_block_hash()
+        );
 
         let block = Block::generate(
             &mut self.transactions,
@@ -426,7 +429,7 @@ mod tests {
     #[test]
     fn mempool_new_test() {
         let mut wallet = Wallet::new();
-	wallet.load_keys("test/testwallet", Some("asdf"));
+        wallet.load_keys("test/testwallet", Some("asdf"));
         let mempool = Mempool::new(Arc::new(RwLock::new(wallet)));
         assert_eq!(mempool.blocks_queue, VecDeque::new());
     }
@@ -434,7 +437,7 @@ mod tests {
     #[test]
     fn mempool_add_block_test() {
         let mut wallet = Wallet::new();
-	wallet.load_keys("test/testwallet", Some("asdf"));
+        wallet.load_keys("test/testwallet", Some("asdf"));
         let mut mempool = Mempool::new(Arc::new(RwLock::new(wallet)));
 
         let block = Block::new();
@@ -447,10 +450,10 @@ mod tests {
     #[tokio::test]
     async fn mempool_bundle_blocks_test() {
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
+        {
             let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
@@ -520,10 +523,10 @@ mod tests {
     #[tokio::test]
     async fn mempool_bundle_and_process_blocks_test() {
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
+        {
             let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -425,14 +425,16 @@ mod tests {
 
     #[test]
     fn mempool_new_test() {
-        let wallet = Wallet::new("test/testwallet", Some("asdf"));
+        let mut wallet = Wallet::new();
+	wallet.load_keys("test/testwallet", Some("asdf"));
         let mempool = Mempool::new(Arc::new(RwLock::new(wallet)));
         assert_eq!(mempool.blocks_queue, VecDeque::new());
     }
 
     #[test]
     fn mempool_add_block_test() {
-        let wallet = Wallet::new("test/testwallet", Some("asdf"));
+        let mut wallet = Wallet::new();
+	wallet.load_keys("test/testwallet", Some("asdf"));
         let mut mempool = Mempool::new(Arc::new(RwLock::new(wallet)));
 
         let block = Block::new();
@@ -444,7 +446,11 @@ mod tests {
 
     #[tokio::test]
     async fn mempool_bundle_blocks_test() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+            let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
@@ -513,7 +519,11 @@ mod tests {
     }
     #[tokio::test]
     async fn mempool_bundle_and_process_blocks_test() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+            let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;

--- a/src/networking/network.rs
+++ b/src/networking/network.rs
@@ -264,7 +264,11 @@ mod tests {
         let mut settings = config::Config::default();
         settings.merge(config::File::with_name("config")).unwrap();
 
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+	    let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
 
@@ -348,7 +352,11 @@ mod tests {
         let mut settings = config::Config::default();
         settings.merge(config::File::with_name("config")).unwrap();
 
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+	    let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
 
@@ -397,7 +405,11 @@ mod tests {
         let mut settings = config::Config::default();
         settings.merge(config::File::with_name("config")).unwrap();
 
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+	    let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let (blockchain_lock, block_hashes) =
             make_mock_blockchain(wallet_lock.clone(), 4 as u64).await;
@@ -440,7 +452,11 @@ mod tests {
         let mut settings = config::Config::default();
         settings.merge(config::File::with_name("config")).unwrap();
 
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+	    let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let (blockchain_lock, _block_hashes) =
             make_mock_blockchain(wallet_lock.clone(), 1 as u64).await;

--- a/src/networking/network.rs
+++ b/src/networking/network.rs
@@ -265,10 +265,10 @@ mod tests {
         settings.merge(config::File::with_name("config")).unwrap();
 
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
-	    let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+        {
+            let mut wallet = wallet_lock.write().await;
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
 
@@ -353,10 +353,10 @@ mod tests {
         settings.merge(config::File::with_name("config")).unwrap();
 
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
-	    let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+        {
+            let mut wallet = wallet_lock.write().await;
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
 
@@ -406,10 +406,10 @@ mod tests {
         settings.merge(config::File::with_name("config")).unwrap();
 
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
-	    let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+        {
+            let mut wallet = wallet_lock.write().await;
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let (blockchain_lock, block_hashes) =
             make_mock_blockchain(wallet_lock.clone(), 4 as u64).await;
@@ -453,10 +453,10 @@ mod tests {
         settings.merge(config::File::with_name("config")).unwrap();
 
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
-	    let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+        {
+            let mut wallet = wallet_lock.write().await;
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let (blockchain_lock, _block_hashes) =
             make_mock_blockchain(wallet_lock.clone(), 1 as u64).await;

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -304,7 +304,11 @@ mod tests {
     }
     #[tokio::test]
     async fn slip_addition_and_removal_from_utxoset() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::new("test/testwallet", Some("asdf"))));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
+	{
+            let mut wallet = wallet_lock.write().await;
+	    wallet.load_keys("test/testwallet", Some("asdf"));
+	}
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let mut blockchain = blockchain_lock.write().await;
         let wallet = wallet_lock.write().await;

--- a/src/slip.rs
+++ b/src/slip.rs
@@ -305,10 +305,10 @@ mod tests {
     #[tokio::test]
     async fn slip_addition_and_removal_from_utxoset() {
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
-	{
+        {
             let mut wallet = wallet_lock.write().await;
-	    wallet.load_keys("test/testwallet", Some("asdf"));
-	}
+            wallet.load_keys("test/testwallet", Some("asdf"));
+        }
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let mut blockchain = blockchain_lock.write().await;
         let wallet = wallet_lock.write().await;

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -314,7 +314,8 @@ impl Staking {
             // reset stakers if necessary
             //
             if self.stakers.is_empty() {
-                let (_res_spend, _res_unspend, _res_delete) = self.reset_staker_table(block.get_staking_treasury());
+                let (_res_spend, _res_unspend, _res_delete) =
+                    self.reset_staker_table(block.get_staking_treasury());
             }
         } else {
             //

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -540,7 +540,7 @@ mod tests {
 
     #[tokio::test]
     async fn blockchain_roll_forward_staking_table_test() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::default()));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
         let mut latest_block_hash = [0; 32];
@@ -765,7 +765,7 @@ mod tests {
 
     #[tokio::test]
     async fn blockchain_staking_deposits_test() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::default()));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let publickey;
         let mut latest_block_hash = [0; 32];
@@ -966,7 +966,7 @@ mod tests {
 
     #[tokio::test]
     async fn blockchain_roll_forward_staking_table_test_with_test_manager() {
-        let wallet_lock = Arc::new(RwLock::new(Wallet::default()));
+        let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
         let mut test_manager = TestManager::new(blockchain_lock.clone(), wallet_lock.clone());
 

--- a/src/test_utilities/mocks.rs
+++ b/src/test_utilities/mocks.rs
@@ -209,7 +209,8 @@ pub fn make_mock_block(
         timestamp,
         prev_timestamp,
     );
-    let wallet = Wallet::new("test/testwallet", Some("asdf"));
+    let mut wallet = Wallet::new();
+    wallet.load_keys("test/testwallet", Some("asdf"));
     let mut mock_input = Slip::new();
     mock_input.set_publickey(wallet.get_publickey());
     mock_input.set_uuid([0; 32]);

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -996,7 +996,7 @@ mod tests {
     fn transaction_sign_test() {
         let mut tx = Transaction::new();
         let mut wallet = Wallet::new();
-	wallet.load_keys("test/testwallet", Some("asdf"));
+        wallet.load_keys("test/testwallet", Some("asdf"));
 
         tx.set_outputs(vec![Slip::new()]);
         tx.sign(wallet.get_privatekey());

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -995,7 +995,8 @@ mod tests {
     #[test]
     fn transaction_sign_test() {
         let mut tx = Transaction::new();
-        let wallet = Wallet::new("test/testwallet", Some("asdf"));
+        let mut wallet = Wallet::new();
+	wallet.load_keys("test/testwallet", Some("asdf"));
 
         tx.set_outputs(vec![Slip::new()]);
         tx.sign(wallet.get_privatekey());

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -7,8 +7,8 @@ use std::path::Path;
 
 use crate::block::Block;
 use crate::crypto::{
-    generate_keys, hash, generate_keypair_from_privatekey, sign, SaitoHash, SaitoPrivateKey, SaitoPublicKey,
-    SaitoSignature, SaitoUTXOSetKey,
+    generate_keypair_from_privatekey, generate_keys, hash, sign, SaitoHash, SaitoPrivateKey,
+    SaitoPublicKey, SaitoSignature, SaitoUTXOSetKey,
 };
 use crate::golden_ticket::GoldenTicket;
 use crate::slip::{Slip, SlipType};
@@ -67,13 +67,11 @@ impl Wallet {
             decrypted_buffer = Wallet::read_key_file(&key_path, &password);
         }
 
-	let (publickey, privatekey) = generate_keypair_from_privatekey(&decrypted_buffer);
+        let (publickey, privatekey) = generate_keypair_from_privatekey(&decrypted_buffer);
 
-	self.set_publickey(publickey);
-	self.set_privatekey(privatekey);
-
+        self.set_publickey(publickey);
+        self.set_privatekey(privatekey);
     }
-
 
     fn create_key_file(key_file_path: &str, opts_password: &Option<&str>) -> Vec<u8> {
         let password: String;
@@ -217,11 +215,11 @@ impl Wallet {
         self.publickey
     }
 
-    pub fn set_privatekey(&mut self, privatekey : SaitoPrivateKey) {
+    pub fn set_privatekey(&mut self, privatekey: SaitoPrivateKey) {
         self.privatekey = privatekey;
     }
 
-    pub fn set_publickey(&mut self, publickey : SaitoPublicKey) {
+    pub fn set_publickey(&mut self, publickey: SaitoPublicKey) {
         self.publickey = publickey;
     }
 


### PR DESCRIPTION
This reverts the Wallet constructor to avoid needing a wallet file and password. Instead of providing the wallet file as part of the constructor, the software will auto-generate on start and optionally call wallet.load_keys(file, pswd) to load content that exists in the provided walletfile. There are several reasons why the reversion is preferred:

* less clutter - Wallet::new()
* consistency - other classes use new() by convention
* simpler tests - most do not need a pre-generated wallet or are better with a random keypair.
* less dependence on external files - minimize potential for errors
* extensible - load_ functions are the proper place for code to load data
* saving & loading - should be parallel functions which can be called anytime, not just at init

All files and tests have been updated and appear to be working perfectly.