### PR TITLE
Architectural simplifications and corner sanding

### DIFF
--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -118,17 +118,10 @@ pub async fn main() -> saito_rust::Result<()> {
 
         event!(Level::INFO, "{:?}", server_transaction_url);
 
-println!("about to start creating transactions");
-
         loop {
-println!("looping in creating txs");
             let mut transactions: Vec<Transaction> = vec![];
 
-println!("txs to generate: {}", txs_to_generate);
-
             event!(Level::INFO, "TXS TO GENERATE: {:?}", txs_to_generate);
-
-println!("txs to generate 2: {}", txs_to_generate);
 
             for _i in 0..txs_to_generate {
                 let mut transaction =
@@ -158,11 +151,8 @@ println!("txs to generate 2: {}", txs_to_generate);
                 transactions.push(transaction);
             }
 
-println!("looping through txs and submitting to server!");
-
             for tx in transactions {
                 let bytes: Vec<u8> = tx.serialize_for_net();
-println!("sending to {}", &server_transaction_url[..]);
                 let result = client
                     .post(&server_transaction_url[..])
                     .body(bytes)
@@ -177,18 +167,11 @@ println!("sending to {}", &server_transaction_url[..]);
                     }
                 }
             }
-println!("and spammer loop going to sleep....");
             sleep(Duration::from_millis(4000));
         }
     });
 
-println!("-----------------------------");
-println!("About to run the spammer CODE");
-println!("-----------------------------");
     run(mempool_lock.clone(), wallet_lock.clone(), blockchain_lock.clone(), miner_lock.clone(), network_lock.clone()).await?;
-println!("-----------------------------");
-println!("DONE running the spammer CODE");
-println!("-----------------------------");
 
     Ok(())
 }
@@ -201,7 +184,6 @@ pub async fn run(
     network_lock: Arc<RwLock<Network>>,
 ) -> saito_rust::Result<()> {
     let (broadcast_channel_sender, broadcast_channel_receiver) = broadcast::channel(32);
-println!("about to start up the network 2!");
     tokio::select! {
         res = saito_rust::mempool::run(
             mempool_lock.clone(),
@@ -244,6 +226,5 @@ println!("about to start up the network 2!");
             }
         },
     }
-    println!("exiting..?");
     Ok(())
 }

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -146,8 +146,6 @@ pub async fn main() -> saito_rust::Result<()> {
                     .add_hop_to_path(wallet_lock_clone.clone(), publickey)
                     .await;
 
-                //println!("TRANSACTION: {:?}", transaction);
-
                 transactions.push(transaction);
             }
 
@@ -159,8 +157,8 @@ pub async fn main() -> saito_rust::Result<()> {
                     .send()
                     .await;
                 match result {
-                    Ok(response) => {
-                        println!("response {:?}", response);
+                    Ok(_response) => {
+                        //println!("response {:?}", response);
                     }
                     Err(error) => {
                         println!("Error sending tx to node: {}", error);

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -243,20 +243,6 @@ println!("about to start up the network 2!");
                 eprintln!("network err {:?}", err)
             }
         },
-/****
-        res = saito_rust::networking::network::run_server(
-            network_lock.clone(),
-            wallet_lock.clone(),
-            mempool_lock.clone(),
-            blockchain_lock.clone(),
-            broadcast_channel_sender.clone(),
-            broadcast_channel_sender.subscribe()
-        ) => {
-            if let Err(err) = res {
-                eprintln!("run_server err {:?}", err)
-            }
-        },
-***/
     }
     println!("exiting..?");
     Ok(())

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -85,16 +85,14 @@ pub async fn main() -> saito_rust::Result<()> {
         wallet.load_keys("test/testwallet", Some("asdf"));
     }
     let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
-
     let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
     let miner_lock = Arc::new(RwLock::new(Miner::new(wallet_lock.clone())));
-
-    let network = Network::new(
+    let network_lock = Arc::new(RwLock::new(Network::new(
         settings.clone(),
         wallet_lock.clone(),
         mempool_lock.clone(),
         blockchain_lock.clone(),
-    );
+    )));
 
     let publickey;
     let privatekey;
@@ -105,6 +103,7 @@ pub async fn main() -> saito_rust::Result<()> {
         privatekey = wallet.get_privatekey();
     }
 
+    let wallet_lock_clone = wallet_lock.clone();
     tokio::spawn(async move {
         let client = reqwest::Client::new();
 
@@ -123,7 +122,7 @@ pub async fn main() -> saito_rust::Result<()> {
 
             for _i in 0..txs_to_generate {
                 let mut transaction =
-                    Transaction::generate_transaction(wallet_lock.clone(), publickey, 5000, 5000)
+                    Transaction::generate_transaction(wallet_lock_clone.clone(), publickey, 5000, 5000)
                         .await;
                 transaction.set_message(
                     (0..bytes_per_tx)
@@ -138,10 +137,10 @@ pub async fn main() -> saito_rust::Result<()> {
 
                 // add some test hops ...
                 transaction
-                    .add_hop_to_path(wallet_lock.clone(), publickey)
+                    .add_hop_to_path(wallet_lock_clone.clone(), publickey)
                     .await;
                 transaction
-                    .add_hop_to_path(wallet_lock.clone(), publickey)
+                    .add_hop_to_path(wallet_lock_clone.clone(), publickey)
                     .await;
 
                 //println!("TRANSACTION: {:?}", transaction);
@@ -169,16 +168,17 @@ pub async fn main() -> saito_rust::Result<()> {
         }
     });
 
-    run(mempool_lock, blockchain_lock, miner_lock, network).await?;
+    run(mempool_lock.clone(), wallet_lock.clone(), blockchain_lock.clone(), miner_lock.clone(), network_lock.clone()).await?;
 
     Ok(())
 }
 
 pub async fn run(
     mempool_lock: Arc<RwLock<Mempool>>,
+    wallet_lock: Arc<RwLock<Wallet>>,
     blockchain_lock: Arc<RwLock<Blockchain>>,
     miner_lock: Arc<RwLock<Miner>>,
-    network: Network,
+    network_lock: Arc<RwLock<Network>>,
 ) -> saito_rust::Result<()> {
     let (broadcast_channel_sender, broadcast_channel_receiver) = broadcast::channel(32);
     tokio::select! {
@@ -210,14 +210,26 @@ pub async fn run(
                 eprintln!("{:?}", err)
             }
         },
-        res = network.run_server() => {
+        res = saito_rust::networking::network::run(
+            network_lock.clone(),
+            wallet_lock.clone(),
+            broadcast_channel_sender.clone(),
+            broadcast_channel_sender.subscribe()
+        ) => {
             if let Err(err) = res {
-                eprintln!("{:?}", err)
+                eprintln!("network err {:?}", err)
             }
         },
-        res = network.run() => {
+        res = saito_rust::networking::network::run_server(
+            network_lock.clone(),
+            wallet_lock.clone(),
+            mempool_lock.clone(),
+            blockchain_lock.clone(),
+            broadcast_channel_sender.clone(),
+            broadcast_channel_sender.subscribe()
+        ) => {
             if let Err(err) = res {
-                eprintln!("{:?}", err)
+                eprintln!("run_server err {:?}", err)
             }
         },
     }

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -105,9 +105,7 @@ pub async fn main() -> saito_rust::Result<()> {
 
     let wallet_lock_clone = wallet_lock.clone();
 
-
     tokio::spawn(async move {
-
         let client = reqwest::Client::new();
 
         let host: [u8; 4] = settings.get::<[u8; 4]>("network.host").unwrap();
@@ -124,9 +122,13 @@ pub async fn main() -> saito_rust::Result<()> {
             event!(Level::INFO, "TXS TO GENERATE: {:?}", txs_to_generate);
 
             for _i in 0..txs_to_generate {
-                let mut transaction =
-                    Transaction::generate_transaction(wallet_lock_clone.clone(), publickey, 5000, 5000)
-                        .await;
+                let mut transaction = Transaction::generate_transaction(
+                    wallet_lock_clone.clone(),
+                    publickey,
+                    5000,
+                    5000,
+                )
+                .await;
                 transaction.set_message(
                     (0..bytes_per_tx)
                         .into_par_iter()
@@ -169,7 +171,14 @@ pub async fn main() -> saito_rust::Result<()> {
         }
     });
 
-    run(mempool_lock.clone(), wallet_lock.clone(), blockchain_lock.clone(), miner_lock.clone(), network_lock.clone()).await?;
+    run(
+        mempool_lock.clone(),
+        wallet_lock.clone(),
+        blockchain_lock.clone(),
+        miner_lock.clone(),
+        network_lock.clone(),
+    )
+    .await?;
 
     Ok(())
 }
@@ -214,8 +223,8 @@ pub async fn run(
         res = saito_rust::networking::network::run(
             network_lock.clone(),
             wallet_lock.clone(),
-	    mempool_lock.clone(),
-	    blockchain_lock.clone(),
+        mempool_lock.clone(),
+        blockchain_lock.clone(),
             broadcast_channel_sender.clone(),
             broadcast_channel_sender.subscribe()
         ) => {

--- a/src/bin/spammer.rs
+++ b/src/bin/spammer.rs
@@ -181,6 +181,7 @@ pub async fn run(
     network_lock: Arc<RwLock<Network>>,
 ) -> saito_rust::Result<()> {
     let (broadcast_channel_sender, broadcast_channel_receiver) = broadcast::channel(32);
+println!("about to start up the network 2!");
     tokio::select! {
         res = saito_rust::mempool::run(
             mempool_lock.clone(),

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1265,25 +1265,6 @@ pub async fn run(
                             SaitoMessage::MempoolNewBlock { hash: _hash } => {
                                 println!("Blockchain aware of new block in mempool! -- we might use for this congestion tracking");
                             },
-
-        //
-        // TODO - delete - keeping as quick reference for multiple ways
-        // to broadcast messages.
-        //
-        //                    SaitoMessage::TestMessage => {
-        //             		println!("Blockchain GOT TEST MESSAGE!");
-        //			let blockchain = blockchain_lock.read().await;
-        //
-        //			broadcast_channel_sender.send(SaitoMessage::TestMessage2).unwrap();
-        //
-        //		        if !blockchain.broadcast_channel_sender.is_none() {
-        //			    println!("blockchain broadcast channel sender exists!");
-        //
-        //	      		    blockchain.broadcast_channel_sender.as_ref().unwrap()
-        //                        	.send(SaitoMessage::TestMessage3)
-        //                        	.expect("error: Mempool TryBundle Block message failed to send");
-        //        		}
-        //                    },
                             _ => {},
                         }
                     }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -92,8 +92,8 @@ impl Blockchain {
         let block_id = block.get_id();
         let previous_block_hash = self.blockring.get_latest_block_hash();
 
-        println!("blockring reports prev hash: {:?}", previous_block_hash);
-        println!("block reports: {:?}", block.get_previous_block_hash());
+        println!("blockring prev hash: {:?}", previous_block_hash);
+        println!("block     prev hash: {:?}", block.get_previous_block_hash());
 
         //
         // sanity checks
@@ -784,7 +784,6 @@ impl Blockchain {
             create_timestamp()
         );
 
-        println!("This is wind chain");
         //
         // if we are winding a non-existent chain with a wind_failure it
         // means our wind attempt failed and we should move directly into
@@ -837,8 +836,6 @@ impl Blockchain {
             create_timestamp()
         );
         let does_block_validate = block.validate(&self, &self.utxoset, &self.staking).await;
-
-        println!("DOES BV: {}", does_block_validate);
 
         event!(
             Level::TRACE,

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1259,8 +1259,8 @@ pub async fn run(
                 //
                     Ok(message) = broadcast_channel_receiver.recv() => {
                         match message {
-                            SaitoMessage::MempoolNewBlock { hash: _hash } => {
-                                println!("Blockchain aware of new block in mempool! -- we might use for this congestion tracking");
+                            SaitoMessage::NetworkNewBlock { hash: _hash } => {
+                                println!("Blockchain aware network has received new block! -- we might use for this congestion tracking");
                             },
                             _ => {},
                         }

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -1245,27 +1245,27 @@ pub async fn run(
     loop {
         tokio::select! {
 
-                //
-                // local broadcast messages
-                //
-                    Some(message) = blockchain_channel_receiver.recv() => {
-                        match message {
-                            _ => {},
-                        }
-                    }
-
-                //
-                // global broadcast messages
-                //
-                    Ok(message) = broadcast_channel_receiver.recv() => {
-                        match message {
-                            SaitoMessage::NetworkNewBlock { hash: _hash } => {
-                                println!("Blockchain aware network has received new block! -- we might use for this congestion tracking");
-                            },
-                            _ => {},
-                        }
-                    }
+        //
+        // local broadcast messages
+        //
+            Some(message) = blockchain_channel_receiver.recv() => {
+                match message {
+                    _ => {},
                 }
+            }
+
+        //
+        // global broadcast messages
+        //
+            Ok(message) = broadcast_channel_receiver.recv() => {
+                match message {
+                    SaitoMessage::NetworkNewBlock { hash: _hash } => {
+                        println!("Blockchain aware network has received new block! -- we might use for this congestion tracking");
+                    },
+                    _ => {},
+                }
+            }
+        }
     }
 }
 

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -235,6 +235,8 @@ impl Consensus {
             res = crate::networking::network::run(
 		network_lock.clone(),
 		wallet_lock.clone(),
+		mempool_lock.clone(),
+		blockchain_lock.clone(),
                 broadcast_channel_sender.clone(),
                 broadcast_channel_sender.subscribe()
 	    ) => {
@@ -242,6 +244,7 @@ impl Consensus {
                     eprintln!("network err {:?}", err)
                 }
             },
+/****
             res = crate::networking::network::run_server(
 		network_lock.clone(),
 		wallet_lock.clone(),
@@ -254,7 +257,7 @@ impl Consensus {
                     eprintln!("run_server err {:?}", err)
                 }
             },
-
+****/
 	    //
 	    // Other
 	    //

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -244,20 +244,7 @@ impl Consensus {
                     eprintln!("network err {:?}", err)
                 }
             },
-/****
-            res = crate::networking::network::run_server(
-		network_lock.clone(),
-		wallet_lock.clone(),
-		mempool_lock.clone(),
-		blockchain_lock.clone(),
-                broadcast_channel_sender.clone(),
-                broadcast_channel_sender.subscribe()
-	    ) => {
-                if let Err(err) = res {
-                    eprintln!("run_server err {:?}", err)
-                }
-            },
-****/
+
 	    //
 	    // Other
 	    //

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -10,33 +10,40 @@ use std::sync::Arc;
 use tokio::signal;
 use tokio::sync::RwLock;
 use tokio::sync::{broadcast, mpsc};
-/// The consensus state which exposes a run method
-/// initializes Saito state
-struct Consensus {
-    _notify_shutdown: broadcast::Sender<()>,
-    _shutdown_complete_rx: mpsc::Receiver<()>,
-    _shutdown_complete_tx: mpsc::Sender<()>,
-}
 
-/// The types of messages broadcast over the main
-/// broadcast channel in normal operations.
+///
+/// Saito has the following system-wide messages which may be sent and received
+/// over the main broadcast channel. Convention has the message begin with the 
+/// class that is broadcasting.
+///
+/// TODO - MempoolNewBlock and MempoolNewTransaction are not used at present in
+/// network design, and are misnamed according to convention as Mempool is the 
+/// receiving class not the emitting class. 
+///
 #[derive(Clone, Debug)]
 pub enum SaitoMessage {
-    TestMessage,
-    TestMessage2,
-    TestMessage3,
+    // broadcast when the longest chain block changes
     BlockchainNewLongestChainBlock { hash: SaitoHash, difficulty: u64 },
+    // broadcast when a block is successfully added
     BlockchainAddBlockSuccess { hash: SaitoHash },
+    // broadcast when a block is unsuccessful at being added
     BlockchainAddBlockFailure { hash: SaitoHash },
+    // broadcast when the miner finds a golden ticket
     MinerNewGoldenTicket { ticket: GoldenTicket },
+    // broadcast when the mempool produces a new block
     MempoolNewBlock { hash: SaitoHash },
+    // broadcast when the mempool adds a new transaction
     MempoolNewTransaction { transaction: Transaction },
 }
 
-/// Run the Saito consensus runtime
+
+///
+/// The entry point to the Saito consensus runtime
+///
 pub async fn run() -> crate::Result<()> {
+
     //
-    // handle shutdown messages using broadcast channel
+    // handle shutdown messages w/ broadcast channel
     //
     let (notify_shutdown, _) = broadcast::channel(1);
     let (shutdown_complete_tx, shutdown_complete_rx) = mpsc::channel(1);
@@ -46,6 +53,9 @@ pub async fn run() -> crate::Result<()> {
         _shutdown_complete_rx: shutdown_complete_rx,
     };
 
+    //
+    // initiate runtime and handle results
+    //
     tokio::select! {
         res = consensus.run() => {
             if let Err(err) = res {
@@ -60,14 +70,36 @@ pub async fn run() -> crate::Result<()> {
     Ok(())
 }
 
+
+//
+// The consensus state exposes a run method that main
+// calls to initialize Saito state and prepare for
+// shutdown.
+//
+struct Consensus {
+    _notify_shutdown: broadcast::Sender<()>,
+    _shutdown_complete_rx: mpsc::Receiver<()>,
+    _shutdown_complete_tx: mpsc::Sender<()>,
+}
+
 impl Consensus {
-    /// Run consensus
+    //
+    // Run consensus
+    //
     async fn run(&mut self) -> crate::Result<()> {
+
         //
-        // create inter-module broadcast channels
+        // create main broadcast channel
         //
+	// all major classes have send/receive access to the main broadcast
+	// channel, and can communicate by sending the events listed in the
+	// SaitoMessage list above.
+	//
         let (broadcast_channel_sender, broadcast_channel_receiver) = broadcast::channel(32);
 
+	//
+	// handle command-line arguments
+	//
         let matches = App::new("Saito Runtime")
             .about("Runs a Saito Node")
             .arg(
@@ -106,34 +138,39 @@ impl Consensus {
 
         let key_path = matches.value_of("key_path").unwrap();
         let password = matches.value_of("password");
-        //
-        // all objects requiring multithread read / write access are
-        // wrapped in Tokio::RwLock for read().await / write().await
-        // access. This requires cloning the lock and that clone
-        // being sent into the async threads rather than the original
-        //
-        // major classes get a clone of the broadcast channel sender
-        // which is assigned to them on Object::run so they can
-        // broadcast cross-system messages. See SaitoMessage ENUM above
-        // for information on cross-system notifications.
-        //
+
+
+
+	//
+	// generate/load the wallet
+	//
         let wallet_lock = Arc::new(RwLock::new(Wallet::new()));
         {
             let mut wallet = wallet_lock.write().await;
             wallet.load_keys(key_path, password);
         }
 
+	//
+	// load blocks from disk 
+	//
         let blockchain_lock = Arc::new(RwLock::new(Blockchain::new(wallet_lock.clone())));
-        // Load blocks from disk if configured
         let load_blocks_from_disk = match settings.get::<bool>("storage.load_blocks_from_disk") {
             Ok(can_load) => can_load,
-            // we load by default
             Err(_) => true,
         };
-
         if load_blocks_from_disk {
             Storage::load_blocks_from_disk(blockchain_lock.clone()).await;
         }
+
+
+	//
+	// instantiate core classes
+	//
+        // all major classes which require multithread read / write access are
+        // wrapped in Tokio::RwLock for read().await / write().await access. 
+	// we will send a clone of this RwLock object in any object that will
+	// require direct access when initializing the object below.
+        //
         let mempool_lock = Arc::new(RwLock::new(Mempool::new(wallet_lock.clone())));
         let miner_lock = Arc::new(RwLock::new(Miner::new(wallet_lock.clone())));
         let network = Network::new(
@@ -142,7 +179,23 @@ impl Consensus {
             mempool_lock.clone(),
             blockchain_lock.clone(),
         );
+
+	//
+        // initialize core classes.
+	//
+        // all major classes get a clone of the broadcast channel sender and
+	// broadcast channel receiver. They must receive this clone and assign
+	// it to a local object so they have read/write access to cross-system
+	// messages.
+	//
+        // The SaitoMessage ENUM above contains a list of all cross-
+	// system notifications.
+        //
         tokio::select! {
+
+	    //
+	    // Mempool
+	    //
             res = crate::mempool::run(
                 mempool_lock.clone(),
                 blockchain_lock.clone(),
@@ -153,6 +206,10 @@ impl Consensus {
                     eprintln!("mempool err {:?}", err)
                 }
             },
+
+	    //
+	    // Blockchain
+	    //
             res = crate::blockchain::run(
                 blockchain_lock.clone(),
                 broadcast_channel_sender.clone(),
@@ -162,6 +219,10 @@ impl Consensus {
                     eprintln!("blockchain err {:?}", err)
                 }
             },
+
+	    //
+	    // Miner
+	    //
             res = crate::miner::run(
                 miner_lock.clone(),
                 broadcast_channel_sender.clone(),
@@ -171,6 +232,10 @@ impl Consensus {
                     eprintln!("miner err {:?}", err)
                 }
             },
+
+	    //
+	    // Network
+	    //
             res = network.run() => {
                 if let Err(err) = res {
                     eprintln!("network err {:?}", err)
@@ -181,6 +246,10 @@ impl Consensus {
                     eprintln!("run_server err {:?}", err)
                 }
             },
+
+	    //
+	    // Other
+	    //
             _ = self._shutdown_complete_tx.closed() => {
                 println!("Shutdown message complete")
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,3 +30,4 @@ pub async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send 
     tracing_subscriber::fmt::init();
     consensus::run().await
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,4 +30,3 @@ pub async fn main() -> std::result::Result<(), Box<dyn std::error::Error + Send 
     tracing_subscriber::fmt::init();
     consensus::run().await
 }
-

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -295,17 +295,20 @@ pub async fn run(
     //
     // mempool gets global broadcast channel and keypair
     //
-    let mut mempool = mempool_lock.write().await;
-    let publickey;
-    let privatekey;
     {
-        let wallet = mempool.wallet_lock.read().await;
-        publickey = wallet.get_publickey();
-        privatekey = wallet.get_privatekey();
+	// do not seize mempool write access
+        let mut mempool = mempool_lock.write().await;
+        let publickey;
+        let privatekey;
+        {
+            let wallet = mempool.wallet_lock.read().await;
+            publickey = wallet.get_publickey();
+            privatekey = wallet.get_privatekey();
+        }
+        mempool.set_broadcast_channel_sender(broadcast_channel_sender.clone());
+        mempool.set_mempool_publickey(publickey);
+        mempool.set_mempool_privatekey(privatekey);
     }
-    mempool.set_broadcast_channel_sender(broadcast_channel_sender.clone());
-    mempool.set_mempool_publickey(publickey);
-    mempool.set_mempool_privatekey(privatekey);
 
 
     //

--- a/src/networking/handlers.rs
+++ b/src/networking/handlers.rs
@@ -75,21 +75,9 @@ pub async fn post_transaction_handler(
             .unwrap()
             .to_string();
 
-        //let response = String::from("OK");
         let mut mempool = mempool_lock.write().await;
-        let add_tx_result = mempool.add_transaction(tx).await;
-        match add_tx_result {
-            crate::mempool::AddTransactionResult::Accepted => Ok(Message { msg: response }),
-            crate::mempool::AddTransactionResult::Exists => {
-                Err(warp::reject::custom(AlreadyExists))
-            }
-            crate::mempool::AddTransactionResult::Invalid => {
-                panic!("This appears unused, implement if needed");
-            }
-            crate::mempool::AddTransactionResult::Rejected => {
-                panic!("This appears unused, implement if needed");
-            }
-        }
+        mempool.add_transaction(tx).await;
+	Ok(Message { msg: response })
     } else {
         Err(warp::reject::custom(Invalid))
     }

--- a/src/networking/handlers.rs
+++ b/src/networking/handlers.rs
@@ -100,7 +100,6 @@ pub async fn get_block_handler(str_block_hash: String) -> Result<impl Reply> {
     match Storage::stream_block_from_disk(block_hash).await {
         Ok(block_bytes) => Ok(block_bytes),
         Err(_err) => {
-            eprintln!("{:?}", _err);
             Err(warp::reject())
         }
     }
@@ -113,7 +112,6 @@ pub async fn get_block_handler(str_block_hash: String) -> Result<impl Reply> {
 //     match Storage::stream_json_block_from_disk(block_hash).await {
 //         Ok(json_data) => Ok(warp::reply::json(&json_data)),
 //         Err(_err) => {
-//             eprintln!("{:?}", _err);
 //             Err(warp::reject())
 //         }
 //     }

--- a/src/networking/handlers.rs
+++ b/src/networking/handlers.rs
@@ -75,10 +75,13 @@ pub async fn post_transaction_handler(
             .unwrap()
             .to_string();
 
+println!("ADDING TX TO MEMPOOL 1");
         let mut mempool = mempool_lock.write().await;
+println!("ADDING TX TO MEMPOOL 2");
         mempool.add_transaction(tx).await;
 	Ok(Message { msg: response })
     } else {
+println!("WE HAVE AN ERROR WITH THIS TRANSACTION");
         Err(warp::reject::custom(Invalid))
     }
 }

--- a/src/networking/handlers.rs
+++ b/src/networking/handlers.rs
@@ -74,14 +74,10 @@ pub async fn post_transaction_handler(
         let response = std::str::from_utf8(&tx.get_signature().to_base58().as_bytes())
             .unwrap()
             .to_string();
-
-println!("ADDING TX TO MEMPOOL 1");
         let mut mempool = mempool_lock.write().await;
-println!("ADDING TX TO MEMPOOL 2");
         mempool.add_transaction(tx).await;
 	Ok(Message { msg: response })
     } else {
-println!("WE HAVE AN ERROR WITH THIS TRANSACTION");
         Err(warp::reject::custom(Invalid))
     }
 }

--- a/src/networking/handlers.rs
+++ b/src/networking/handlers.rs
@@ -76,7 +76,7 @@ pub async fn post_transaction_handler(
             .to_string();
         let mut mempool = mempool_lock.write().await;
         mempool.add_transaction(tx).await;
-	Ok(Message { msg: response })
+        Ok(Message { msg: response })
     } else {
         Err(warp::reject::custom(Invalid))
     }
@@ -99,9 +99,7 @@ pub async fn get_block_handler(str_block_hash: String) -> Result<impl Reply> {
 
     match Storage::stream_block_from_disk(block_hash).await {
         Ok(block_bytes) => Ok(block_bytes),
-        Err(_err) => {
-            Err(warp::reject())
-        }
+        Err(_err) => Err(warp::reject()),
     }
 }
 

--- a/src/networking/network.rs
+++ b/src/networking/network.rs
@@ -188,42 +188,6 @@ impl Network {
             }
         }
     }
-/*****
-    pub async fn spawn_reconnect_to_configured_peers_task(
-        &self,
-        wallet_lock: Arc<RwLock<Wallet>>,
-    ) -> crate::Result<()> {
-        let _foo = tokio::spawn(async move {
-            loop {
-                let peer_states: Vec<(SaitoHash, bool)>;
-                {
-                    let peers_db_global = PEERS_DB_GLOBAL.clone();
-                    let peers_db = peers_db_global.read().await;
-                    peer_states = peers_db
-                        .keys()
-                        .map(|connection_id| {
-                            let peer = peers_db.get(connection_id).unwrap();
-                            let should_try_reconnect = peer.get_is_from_peer_list()
-                                && !peer.get_is_connected_or_connecting();
-                            (*connection_id, should_try_reconnect)
-                        })
-                        .collect::<Vec<(SaitoHash, bool)>>();
-                }
-                for (connection_id, should_try_reconnect) in peer_states {
-                    if should_try_reconnect {
-                        println!("found disconnected peer in peer settings, connecting...");
-                        Network::connect_to_peer(connection_id, wallet_lock.clone()).await;
-                    }
-                }
-                sleep(Duration::from_millis(1000));
-            }
-        })
-        .await
-        .expect("error: spawn_reconnect_to_configured_peers_task failed");
-        Ok(())
-    }
-*****/
-
 }
 
 
@@ -281,21 +245,6 @@ pub async fn run(
         ));
 
 
-
-
-    //
-    // spawn loop to reconnect to peers
-    //
-    //let network_lock_clone = network_lock.clone();
-    //tokio::spawn(async move {
-    //    loop {
-//	    reconnect_to_dropped_peers(wallet_lock.clone());
-//            sleep(Duration::from_millis(1000)).await;
-//        }
-//    });
-
-
-
     //
     // create local broadcast channel
     //
@@ -317,14 +266,13 @@ pub async fn run(
     });
 
 
+
     //
     // start the server (separate thread)
     //
     tokio::spawn(async move {
         warp::serve(routes).run((host, port)).await;
     });
-
-
 
 
     //
@@ -352,11 +300,6 @@ pub async fn run(
             //
             Ok(message) = broadcast_channel_receiver.recv() => {
                 match message {
-		    //
-		    // demonstration of global broadcast channels, track golden ticket production
-		    //
-                    SaitoMessage::MinerNewGoldenTicket { ticket : _golden_ticket } => {
-                    },
                     _ => {},
                 }
             }

--- a/src/networking/network.rs
+++ b/src/networking/network.rs
@@ -1,5 +1,6 @@
 use crate::blockchain::Blockchain;
 use crate::crypto::{hash, SaitoHash, SaitoPublicKey};
+use crate::consensus::{SaitoMessage};
 use crate::mempool::Mempool;
 use crate::networking::api_message::APIMessage;
 use crate::networking::filters::{
@@ -11,7 +12,7 @@ use crate::util::format_url_string;
 use crate::wallet::Wallet;
 use futures::StreamExt;
 use secp256k1::PublicKey;
-use tokio::sync::RwLock;
+use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio::time::sleep;
 use tokio_tungstenite::connect_async;
 use uuid::Uuid;
@@ -29,14 +30,29 @@ pub const CHALLENGE_EXPIRATION_TIME: u64 = 60000;
 
 pub type Result<T> = std::result::Result<T, Rejection>;
 
+
+//
+// In addition to responding to global broadcast messages, the
+// network has a local broadcast channel it uses to coordinate
+// attempts to check that connections are stable and clean up
+// problematic peers.
+//
+#[derive(Clone, Debug)]
+pub enum NetworkMessage {
+    LocalNetworkMonitoring,
+}
+
+
 pub struct Network {
     config_settings: Config,
     wallet_lock: Arc<RwLock<Wallet>>,
     mempool_lock: Arc<RwLock<Mempool>>,
     blockchain_lock: Arc<RwLock<Blockchain>>,
+    broadcast_channel_sender: Option<broadcast::Sender<SaitoMessage>>,
 }
 
 impl Network {
+
     pub fn new(
         config_settings: Config,
         wallet_lock: Arc<RwLock<Wallet>>,
@@ -48,8 +64,14 @@ impl Network {
             wallet_lock,
             mempool_lock,
             blockchain_lock,
+            broadcast_channel_sender: None,
         }
     }
+
+    pub fn set_broadcast_channel_sender(&mut self, bcs: broadcast::Sender<SaitoMessage>) {
+        self.broadcast_channel_sender = Some(bcs);
+    }
+
     pub async fn connect_to_peer(connection_id: SaitoHash, wallet_lock: Arc<RwLock<Wallet>>) {
         let peers_db_global = PEERS_DB_GLOBAL.clone();
         let peer_url;
@@ -199,31 +221,116 @@ impl Network {
         .expect("error: spawn_reconnect_to_configured_peers_task failed");
         Ok(())
     }
-    pub async fn run_server(&self) -> crate::Result<()> {
-        let host: [u8; 4] = self.config_settings.get::<[u8; 4]>("network.host").unwrap();
-        let port: u16 = self.config_settings.get::<u16>("network.port").unwrap();
-
-        let routes = get_block_route_filter()
-            .or(post_transaction_route_filter(
-                self.mempool_lock.clone(),
-                self.blockchain_lock.clone(),
-            ))
-            .or(ws_upgrade_route_filter(
-                self.wallet_lock.clone(),
-                self.mempool_lock.clone(),
-                self.blockchain_lock.clone(),
-            ));
-        warp::serve(routes).run((host, port)).await;
-        Ok(())
-    }
-    pub async fn run(&self) -> crate::Result<()> {
-        self.connect_to_configured_peers().await;
-        let _foo = self
-            .spawn_reconnect_to_configured_peers_task(self.wallet_lock.clone())
-            .await;
-        Ok(())
-    }
 }
+
+
+
+pub async fn run(
+    network_lock: Arc<RwLock<Network>>, 
+    wallet_lock: Arc<RwLock<Wallet>>, 
+    broadcast_channel_sender: broadcast::Sender<SaitoMessage>,
+    mut broadcast_channel_receiver: broadcast::Receiver<SaitoMessage>
+) -> crate::Result<()> {
+
+    let mut network = network_lock.write().await;
+
+    //
+    // set global broadcast channel and connect to peers
+    //
+    network.set_broadcast_channel_sender(broadcast_channel_sender.clone());
+    network.connect_to_configured_peers().await;
+    let _foo = network
+        .spawn_reconnect_to_configured_peers_task(wallet_lock.clone())
+        .await;
+
+
+    //
+    // create local broadcast channel
+    //
+    let (network_channel_sender, mut network_channel_receiver) = mpsc::channel(4);
+
+
+    //
+    // local channel sending thread
+    //
+    let network_channel_sender_clone = network_channel_sender.clone();
+    tokio::spawn(async move {
+        loop {
+            network_channel_sender_clone
+                .send(NetworkMessage::LocalNetworkMonitoring)
+                .await
+                .expect("error: LocalNetworkMonitor message failed to send");
+            sleep(Duration::from_millis(10000)).await;
+        }
+    });
+
+
+    //
+    // global and local channel receivers
+    //
+    loop {
+        tokio::select! {
+
+            //
+            // local broadcast channel receivers
+            //
+            Some(message) = network_channel_receiver.recv() => {
+                match message {
+                    //
+                    // attempt to bundle block
+                    //
+                    NetworkMessage::LocalNetworkMonitoring => {
+		        println!("Local Network Monitoring fired!");
+                    },
+                }
+            }
+
+            //
+            // global broadcast channel receivers
+            //
+            Ok(message) = broadcast_channel_receiver.recv() => {
+                match message {
+                    SaitoMessage::MinerNewGoldenTicket { ticket : _golden_ticket } => {
+                        // when miner produces golden ticket
+			println!("Network aware local Golden Ticket produced!");
+                    },
+                    _ => {},
+                }
+            }
+        }
+    }
+
+}
+
+pub async fn run_server(
+    network_lock: Arc<RwLock<Network>>, 
+    wallet_lock: Arc<RwLock<Wallet>>, 
+    mempool_lock: Arc<RwLock<Mempool>>, 
+    blockchain_lock: Arc<RwLock<Blockchain>>, 
+    _broadcast_channel_sender: broadcast::Sender<SaitoMessage>,
+    mut _broadcast_channel_receiver: broadcast::Receiver<SaitoMessage>
+) -> crate::Result<()> {
+
+    let network = network_lock.write().await;
+
+    let host: [u8; 4] = network.config_settings.get::<[u8; 4]>("network.host").unwrap();
+    let port: u16 = network.config_settings.get::<u16>("network.port").unwrap();
+
+    let routes = get_block_route_filter()
+        .or(post_transaction_route_filter(
+            mempool_lock.clone(),
+            blockchain_lock.clone(),
+        ))
+        .or(ws_upgrade_route_filter(
+            wallet_lock.clone(),
+            mempool_lock.clone(),
+            blockchain_lock.clone(),
+        ));
+    warp::serve(routes).run((host, port)).await;
+    Ok(())
+}
+
+
 
 #[cfg(test)]
 mod tests {

--- a/src/networking/network.rs
+++ b/src/networking/network.rs
@@ -232,13 +232,17 @@ pub async fn run(
     mut broadcast_channel_receiver: broadcast::Receiver<SaitoMessage>
 ) -> crate::Result<()> {
 
+println!("network run 1");
     let mut network = network_lock.write().await;
+println!("network run 2");
 
     //
     // set global broadcast channel and connect to peers
     //
     network.set_broadcast_channel_sender(broadcast_channel_sender.clone());
+println!("network run 3");
     network.connect_to_configured_peers().await;
+println!("network run 4");
     let _foo = network
         .spawn_reconnect_to_configured_peers_task(wallet_lock.clone())
         .await;
@@ -247,9 +251,11 @@ pub async fn run(
     //
     // create local broadcast channel
     //
+println!("network run 5");
+println!("network run 6");
+
+/****
     let (network_channel_sender, mut network_channel_receiver) = mpsc::channel(4);
-
-
     //
     // local channel sending thread
     //
@@ -264,6 +270,8 @@ pub async fn run(
         }
     });
 
+println!("network run 4");
+***/
 
     //
     // global and local channel receivers
@@ -299,7 +307,9 @@ pub async fn run(
             }
         }
     }
+***/
 
+    Ok(())
 }
 
 pub async fn run_server(
@@ -316,6 +326,8 @@ pub async fn run_server(
     let host: [u8; 4] = network.config_settings.get::<[u8; 4]>("network.host").unwrap();
     let port: u16 = network.config_settings.get::<u16>("network.port").unwrap();
 
+println!("Starting our server....");
+
     let routes = get_block_route_filter()
         .or(post_transaction_route_filter(
             mempool_lock.clone(),
@@ -327,6 +339,7 @@ pub async fn run_server(
             blockchain_lock.clone(),
         ));
     warp::serve(routes).run((host, port)).await;
+println!("done running warp server");
     Ok(())
 }
 

--- a/src/networking/peer.rs
+++ b/src/networking/peer.rs
@@ -375,8 +375,9 @@ impl SaitoPeer {
                 if let Some(tx) = socket_receive_transaction(api_message.clone()) {
                     let mut mempool = mempool_lock.write().await;
                     mempool.add_transaction(tx).await;
-                    peer.send_response_from_str(api_message.message_id, "OK").await;
-		    // in event of error
+                    peer.send_response_from_str(api_message.message_id, "OK")
+                        .await;
+                    // in event of error
                     //peer.send_error_response(
                     //            api_message.message_id,
                     //            String::from("Invalid").as_bytes().try_into().unwrap(),

--- a/src/networking/peer.rs
+++ b/src/networking/peer.rs
@@ -489,14 +489,7 @@ impl SaitoPeer {
             "REQBLOCK" => {
                 let block = Block::deserialize_for_net(response_api_message.message_data());
                 let mut mempool = self.mempool_lock.write().await;
-                match mempool.add_block_to_queue(block) {
-                    AddBlockResult::Exists => {
-                        println!("The node appears to be requesting blocks which is already has in it's mempool queue, this should probably be fixed...");
-                    }
-                    AddBlockResult::Accepted => {
-                        // nothing to do
-                    }
-                }
+                mempool.add_block(block);
             }
             "REQBLKHD" => {
                 println!("IMPLEMENT REQBLKHD RESPONSE?!");

--- a/src/test_utilities/mocks.rs
+++ b/src/test_utilities/mocks.rs
@@ -3,7 +3,7 @@ use crate::blockchain::Blockchain;
 use crate::burnfee::{BurnFee, HEARTBEAT};
 use crate::crypto::{generate_random_bytes, hash, SaitoHash, SaitoPrivateKey, SaitoPublicKey};
 use crate::golden_ticket::GoldenTicket;
-use crate::mempool::{AddTransactionResult, Mempool};
+use crate::mempool::Mempool;
 use crate::miner::Miner;
 use crate::slip::{Slip, SlipType};
 use crate::time::{create_timestamp, TimestampGenerator};
@@ -90,8 +90,7 @@ pub async fn make_block_with_mempool(
     let transaction = generate_signed_tx(public_key, 1, 100000, wallet_lock.clone()).await;
     {
         let mut mempool = mempool_lock.write().await;
-        let add_tx_result = mempool.add_transaction(transaction).await;
-        assert_eq!(add_tx_result, AddTransactionResult::Accepted);
+        mempool.add_transaction(transaction).await;
     }
 
     mock_timestamp_generator.advance(HEARTBEAT * 2);


### PR DESCRIPTION
This push contains some architectural simplifications and code changes. These changes do not aim to change functionality. They are focused on simplifying the codebase, removing structs that are not being used, and ensuring that different files and classes follow the same organizational logic. Comments have also been added and removed where necessary to provide a better onboarding experience for new developers.

Specific changes include:

CONSENSUS:
 * removal of unused SaitoMessages
 * more intuitive file-organization
 * improved consistency in variable initialization (RwLock)

MEMPOOL:
 * removal of AddBlockAccepted / AddTransactionAccepted
 * simpler and clearer names for LOCAL broadcast channel events
 * simplification of function names and improved naming consistency
 
 NETWORK:
 * implementation now consistent with the other major objects (RwLock)
 * replacement of run and run_server with a single run function
 * new run function handles all thread spawning, avoiding race conditions
 * added support for read/write access to the main broadcast channel
 