### PR TITLE
fix: block header now a block_type, serialization degrades naturally …

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -478,6 +478,11 @@ impl Block {
         }
 
         //
+        // TODO - if the block does not exist on disk, we have to
+        // attempt a remote fetch.
+        //
+
+        //
         // if the block type needed is full and we are not,
         // load the block if it exists on disk.
         //
@@ -698,8 +703,10 @@ impl Block {
         block.set_burnfee(burnfee);
         block.set_difficulty(difficulty);
         block.set_staking_treasury(staking_treasury);
-
         block.set_transactions(&mut transactions);
+        if transactions_len == 0 {
+            block.set_block_type(BlockType::Header);
+        }
         block.generate_hashes();
         block
     }

--- a/src/block.rs
+++ b/src/block.rs
@@ -166,90 +166,9 @@ impl RouterPayout {
 #[derive(Serialize, Deserialize, Debug, Copy, PartialEq, Clone)]
 pub enum BlockType {
     Ghost,
+    Header,
     Pruned,
     Full,
-}
-
-#[serde_with::serde_as]
-#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-pub struct BlockHeader {
-    id: u64,
-    timestamp: u64,
-    previous_block_hash: [u8; 32],
-    #[serde_as(as = "[_; 33]")]
-    creator: [u8; 33],
-    merkle_root: [u8; 32],
-    #[serde_as(as = "[_; 64]")]
-    signature: [u8; 64],
-    treasury: u64,
-    burnfee: u64,
-    difficulty: u64,
-}
-
-impl BlockHeader {
-    #[allow(clippy::new_without_default)]
-    pub fn new(
-        id: u64,
-        timestamp: u64,
-        previous_block_hash: SaitoHash,
-        creator: SaitoPublicKey,
-        merkle_root: SaitoHash,
-        signature: SaitoSignature,
-        treasury: u64,
-        burnfee: u64,
-        difficulty: u64,
-    ) -> Self {
-        Self {
-            id,
-            timestamp,
-            previous_block_hash,
-            creator,
-            merkle_root,
-            signature,
-            treasury,
-            burnfee,
-            difficulty,
-        }
-    }
-
-    pub fn serialize_for_net(&self) -> Vec<u8> {
-        let mut vbytes: Vec<u8> = vec![];
-        vbytes.extend(&self.id.to_be_bytes());
-        vbytes.extend(&self.timestamp.to_be_bytes());
-        vbytes.extend(&self.previous_block_hash);
-        vbytes.extend(&self.creator);
-        vbytes.extend(&self.merkle_root);
-        vbytes.extend(&self.signature);
-        vbytes.extend(&self.treasury.to_be_bytes());
-        vbytes.extend(&self.burnfee.to_be_bytes());
-        vbytes.extend(&self.difficulty.to_be_bytes());
-        vbytes
-    }
-
-    pub fn deserialize_for_net(bytes: Vec<u8>) -> BlockHeader {
-        let id: u64 = u64::from_be_bytes(bytes[4..12].try_into().unwrap());
-        let timestamp: u64 = u64::from_be_bytes(bytes[12..20].try_into().unwrap());
-        let previous_block_hash: SaitoHash = bytes[20..52].try_into().unwrap();
-        let creator: SaitoPublicKey = bytes[52..85].try_into().unwrap();
-        let merkle_root: SaitoHash = bytes[85..117].try_into().unwrap();
-        let signature: SaitoSignature = bytes[117..181].try_into().unwrap();
-
-        let treasury: u64 = u64::from_be_bytes(bytes[181..189].try_into().unwrap());
-        let burnfee: u64 = u64::from_be_bytes(bytes[189..197].try_into().unwrap());
-        let difficulty: u64 = u64::from_be_bytes(bytes[197..205].try_into().unwrap());
-
-        BlockHeader::new(
-            id,
-            timestamp,
-            previous_block_hash,
-            creator,
-            merkle_root,
-            signature,
-            treasury,
-            burnfee,
-            difficulty,
-        )
-    }
 }
 
 #[serde_with::serde_as]
@@ -342,20 +261,6 @@ impl Block {
             // hashmap of all SaitoUTXOSetKeys of the slips in the block
             slips_spent_this_block: AHashMap::new(),
             created_hashmap_of_slips_spent_this_block: false,
-        }
-    }
-
-    pub fn get_header(&self) -> BlockHeader {
-        BlockHeader {
-            id: self.id,
-            timestamp: self.timestamp,
-            previous_block_hash: self.previous_block_hash,
-            creator: self.creator,
-            merkle_root: self.merkle_root,
-            signature: self.signature,
-            treasury: self.treasury,
-            burnfee: self.burnfee,
-            difficulty: self.difficulty,
         }
     }
 
@@ -688,9 +593,16 @@ impl Block {
     /// [burnfee - 8 bytes - u64]
     /// [difficulty - 8 bytes - u64]
     /// [transaction][transaction][transaction]...
-    pub fn serialize_for_net(&self) -> Vec<u8> {
+    pub fn serialize_for_net(&self, block_type: BlockType) -> Vec<u8> {
         let mut vbytes: Vec<u8> = vec![];
-        vbytes.extend(&(self.transactions.iter().len() as u32).to_be_bytes());
+
+        // block headers do not get tx data
+        if block_type == BlockType::Header {
+            vbytes.extend(&(0 as u32).to_be_bytes());
+        } else {
+            vbytes.extend(&(self.transactions.iter().len() as u32).to_be_bytes());
+        }
+
         vbytes.extend(&self.id.to_be_bytes());
         vbytes.extend(&self.timestamp.to_be_bytes());
         vbytes.extend(&self.previous_block_hash);
@@ -702,10 +614,15 @@ impl Block {
         vbytes.extend(&self.burnfee.to_be_bytes());
         vbytes.extend(&self.difficulty.to_be_bytes());
         let mut serialized_txs = vec![];
-        self.transactions.iter().for_each(|transaction| {
-            serialized_txs.extend(transaction.serialize_for_net());
-        });
-        vbytes.extend(serialized_txs);
+
+        // block headers do not get tx data
+        if block_type != BlockType::Header {
+            self.transactions.iter().for_each(|transaction| {
+                serialized_txs.extend(transaction.serialize_for_net());
+            });
+            vbytes.extend(serialized_txs);
+        }
+
         vbytes
     }
     /// Deserialize from bytes to a Block.
@@ -2080,7 +1997,7 @@ mod tests {
         block.set_difficulty(3);
         block.set_transactions(&mut vec![mock_tx, mock_tx2]);
 
-        let serialized_block = block.serialize_for_net();
+        let serialized_block = block.serialize_for_net(BlockType::Full);
         let deserialized_block = Block::deserialize_for_net(&serialized_block);
         // assert_eq!(block, deserialized_block);
         assert_eq!(deserialized_block.get_id(), 1);

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -326,11 +326,12 @@ impl Blockchain {
         //
         // save to disk
         //
-        //let storage = Storage::new();
         {
             let block = self.get_mut_block(&block_hash).await;
             block_id = block.get_id();
-            Storage::write_block_to_disk(block);
+            if block.get_block_type != Block::Header {
+                Storage::write_block_to_disk(block);
+            }
         }
 
         event!(

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -382,7 +382,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        block::Block,
+        block::{Block, BlockType},
         test_utilities::{
             mocks::{add_vip_block, make_block_with_mempool, MockTimestampGenerator},
             test_manager::TestManager,
@@ -542,7 +542,7 @@ mod tests {
 
                 TestManager::check_block_consistency(&latest_block);
 
-                let serialized_latest_block = latest_block.serialize_for_net();
+                let serialized_latest_block = latest_block.serialize_for_net(BlockType::Full);
                 let deserialize_latest_block = Block::deserialize_for_net(&serialized_latest_block);
                 assert_eq!(latest_block.get_hash(), deserialize_latest_block.get_hash());
 

--- a/src/networking/peer.rs
+++ b/src/networking/peer.rs
@@ -1,6 +1,6 @@
 use super::api_message::APIMessage;
 use super::network::CHALLENGE_EXPIRATION_TIME;
-use crate::block::Block;
+use crate::block::{Block, BlockType};
 use crate::blockchain::{Blockchain, GENESIS_PERIOD};
 use crate::crypto::{hash, sign_blob, verify, SaitoHash, SaitoPrivateKey, SaitoPublicKey};
 use crate::mempool::Mempool;
@@ -682,7 +682,7 @@ pub async fn build_request_block_response(
             Some(target_block) => APIMessage::new(
                 "RESULT__",
                 api_message.message_id,
-                target_block.serialize_for_net(),
+                target_block.serialize_for_net(BlockType::Full),
             ),
             None => APIMessage::new_from_string(
                 "ERROR___",
@@ -707,10 +707,7 @@ pub async fn socket_send_block_header(
     let blockchain = blockchain_lock.read().await;
 
     match blockchain.get_block_sync(&block_hash) {
-        Some(target_block) => {
-            let block_header = target_block.get_header();
-            Some(block_header.serialize_for_net())
-        }
+        Some(target_block) => Some(target_block.serialize_for_net(BlockType::Header)),
         None => None,
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -66,7 +66,7 @@ impl Storage {
         let filename = Storage::generate_block_filename(block);
         if !Path::new(&filename).exists() {
             let mut buffer = File::create(filename).unwrap();
-            let byte_array: Vec<u8> = block.serialize_for_net();
+            let byte_array: Vec<u8> = block.serialize_for_net(BlockType::Full);
             buffer.write_all(&byte_array[..]).unwrap();
         }
     }

--- a/src/test_utilities/test_manager.rs
+++ b/src/test_utilities/test_manager.rs
@@ -2,7 +2,7 @@
 // TestManager provides a set of functions to simplify testing. It's goal is to
 // help make tests more succinct.
 //
-use crate::block::Block;
+use crate::block::{Block, BlockType};
 use crate::blockchain::Blockchain;
 use crate::crypto::{SaitoHash, SaitoPrivateKey, SaitoPublicKey, SaitoUTXOSetKey};
 use crate::golden_ticket::GoldenTicket;
@@ -408,7 +408,7 @@ impl TestManager {
         }
     }
     pub fn check_block_consistency(block: &Block) {
-        let serialized_block = block.serialize_for_net();
+        let serialized_block = block.serialize_for_net(BlockType::Full);
 
         let deserialized_block = Block::deserialize_for_net(&serialized_block);
 


### PR DESCRIPTION
This push eliminates BlockHeader as an independent struct. The reasons for this shift:

 - normalization principle (avoid data duplication)
 - header is simply pruned block (BlockType::Header)
 - most elegant approach is upgrade / downgrade
 - eliminates massive amounts of code

Implementation has added an argument specifying the BlockType requested to the serialization code. BlockType::Header requests will simply omit the transactions but include all of the other data. The normal block deserialization functions can handle this type of block. They flag blocks without associated transactions as BlockHeaders.

This has implications for how and when we save to disk which should be considered but are not urgent. In the meantime, I have modified the block-save function to only write blocks to disk if they are Full blocks, to avoid a situation where we save a header and then avoid saving the full block because the file already exists on disk.