### PR TITLE
feat: add SNDBLKHD functionality to network

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Run tests
-        run: RUSTFLAGS="-D warnings" cargo test --verbose
+        run: RUSTFLAGS="-D warnings" cargo test --verbose -- --test-threads=1

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-RUST_BACKTRACE=1 GENESIS_PERIOD=200 cargo test $1 --features=test-utilities
+cargo test $1 -- --nocapture --test-threads=1

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -666,7 +666,6 @@ impl Blockchain {
         //
         0
     }
-
     pub fn print(&self) {
         let latest_block_id = self.get_latest_block_id();
         let mut current_id = latest_block_id;
@@ -1344,7 +1343,7 @@ pub async fn run(
         //
             Ok(message) = broadcast_channel_receiver.recv() => {
                 match message {
-                    SaitoMessage::NetworkNewBlock { hash: _hash } => {
+                    SaitoMessage::MempoolNewBlock { hash: _hash } => {
                         println!("Blockchain aware network has received new block! -- we might use for this congestion tracking");
                     },
                     _ => {},

--- a/src/networking/api_message.rs
+++ b/src/networking/api_message.rs
@@ -61,7 +61,7 @@ impl APIMessage {
     pub fn get_into_message_data(self) -> Vec<u8> {
         self.message_data
     }
-    pub fn get_message_data_as_str(&self) -> String {
+    pub fn get_message_data_as_string(&self) -> String {
         String::from_utf8_lossy(&self.message_data).to_string()
     }
     pub fn deserialize(bytes: &Vec<u8>) -> APIMessage {
@@ -80,5 +80,24 @@ impl APIMessage {
         vbytes.extend(&self.message_id.to_be_bytes());
         vbytes.extend(&self.message_data);
         vbytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::networking::api_message::APIMessage;
+    use std::convert::TryInto;
+
+    #[tokio::test]
+    async fn test_message_serialize() {
+        let api_message = APIMessage {
+            message_name: String::from("HLLOWRLD").as_bytes().try_into().unwrap(),
+            message_id: 1,
+            message_data: String::from("SOMEDATA").as_bytes().try_into().unwrap(),
+        };
+        let serialized_api_message = api_message.serialize();
+
+        let deserialized_api_message = APIMessage::deserialize(&serialized_api_message);
+        assert_eq!(api_message, deserialized_api_message);
     }
 }

--- a/src/networking/handlers.rs
+++ b/src/networking/handlers.rs
@@ -58,6 +58,9 @@ pub async fn ws_upgrade_handler(
 }
 /// POST tx filter.
 /// TODO remove this? I believe we want ot use the socket for everything...
+/// There is a SNDTRANS command which does this, but is currently unused
+/// Let's keep this around for now in case we want to resurrect the spammer...
+/// Once SNDBLKHD is being actively used, this should be deleted.
 pub async fn post_transaction_handler(
     mut body: impl Buf,
     mempool_lock: Arc<RwLock<Mempool>>,

--- a/src/networking/message_types/mod.rs
+++ b/src/networking/message_types/mod.rs
@@ -1,4 +1,5 @@
 pub mod handshake_challenge;
 pub mod request_block_message;
 pub mod request_blockchain_message;
+pub mod send_block_head_message;
 pub mod send_blockchain_message;

--- a/src/networking/message_types/send_block_head_message.rs
+++ b/src/networking/message_types/send_block_head_message.rs
@@ -1,0 +1,52 @@
+use std::convert::TryInto;
+
+use crate::crypto::SaitoHash;
+///
+/// Data Object for SNDBLKHD
+/// `block_hash` - hash of block we wish to inform our peer about
+///
+#[derive(Debug)]
+pub struct SendBlockHeadMessage {
+    block_hash: SaitoHash,
+}
+
+impl SendBlockHeadMessage {
+    pub fn new(block_hash: SaitoHash) -> Self {
+        SendBlockHeadMessage { block_hash }
+    }
+
+    pub fn deserialize(bytes: &Vec<u8>) -> SendBlockHeadMessage {
+        let block_hash: SaitoHash = bytes[0..32].try_into().unwrap();
+
+        SendBlockHeadMessage::new(block_hash)
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut vbytes: Vec<u8> = vec![];
+        vbytes.extend(&self.block_hash);
+        vbytes
+    }
+
+    pub fn get_block_hash(&self) -> &SaitoHash {
+        &self.block_hash
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_send_block_head_message_serialize() {
+        let mock_block_hash = [1; 32];
+        let send_block_head_message = SendBlockHeadMessage::new(mock_block_hash);
+
+        let serialized_send_block_head_message = send_block_head_message.serialize();
+        let deserialized_send_block_head_message =
+            SendBlockHeadMessage::deserialize(&serialized_send_block_head_message);
+        assert_eq!(
+            send_block_head_message.get_block_hash(),
+            deserialized_send_block_head_message.get_block_hash()
+        );
+    }
+}

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -524,8 +524,7 @@ mod tests {
         assert_ne!(wallet.get_privatekey(), [0; 32]);
         assert_eq!(wallet.serialize_for_disk().len(), WALLET_SIZE);
     }
-    // This test panics on github for some reason...
-    #[ignore]
+
     #[test]
     fn save_and_restore_wallet_test() {
         let mut wallet = Wallet::new();


### PR DESCRIPTION
SNDBLKHD work includes SendBlockHeadMessage message, SNDBLKHD test, and relevant functionality in network.rs and peer.rs.

I addition to SNDBLKHD work, this also forces tests to be run with --test-threads=1. This is needed for file storage or any other "global" things that are altered during testing. I believe this also fixes the problem save_and_restore_wallet_test was having on github, so I've un#[ignore]ed it.

I've also cleaned up some issues I had with Network, mostly in run():
1) I've removed the Mutex from around Network. There is no state in Network, therefore it makes little sense to have a Mutex wrapped around it.
2) I've instantiated Network inside of Network::run(). There is no need for any other class to have a reference to Network, so it seems best to just keep it in the network namespace rather than cluttering up consensus.rs.
3) I've removed unneeded internal broadcast channels from network. I don't see the purpose of a channel for a class to communicate with itself.  i.e. spawn_reconnect_to_configured_peers_task is a single function rather than having this functionality split into two places with an unneeded LocalNetworkMonitoring Message passed in between.
4) I've also removed the global_broadcast_channel sender, since it's currently unused. It can easily be re-added later. I prefer not to have dead code laying around.(the receiver is kept and it's Task moved into a separate function from run() for semantic clarity.)
5) I've removed unneeded state from Network. e.g. the config setting can be thrown away once Warp has been started(we were only getting the host and port from these)
6) I've renamed connect_to_configured_peers back to initialize_configured_peers since it only initializes state and doesn't do any connecting. I've also added a comment to make this clearer.
7) Added test for SNDCHAIN and other testing work.