### PR TITLE
feat: blockchain signal network to propagate blocks.

### DIFF
--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -348,7 +348,7 @@ impl Blockchain {
             self.broadcast_channel_sender
                 .as_ref()
                 .unwrap()
-                .send(SaitoMessage::NetworkNewBlock { hash: [0; 32] })
+                .send(SaitoMessage::NetworkNewBlock { hash: block_hash })
                 .expect("error: BlockchainAddBlockFailure message failed to send");
         }
         trace!(" ... block save done:            {:?}", create_timestamp());

--- a/src/blockchain.rs
+++ b/src/blockchain.rs
@@ -344,7 +344,13 @@ impl Blockchain {
                 Storage::write_block_to_disk(block);
             }
         }
-
+        if self.broadcast_channel_sender.is_some() {
+            self.broadcast_channel_sender
+                .as_ref()
+                .unwrap()
+                .send(SaitoMessage::NetworkNewBlock { hash: [0; 32] })
+                .expect("error: BlockchainAddBlockFailure message failed to send");
+        }
         trace!(" ... block save done:            {:?}", create_timestamp());
 
         //
@@ -1302,7 +1308,7 @@ pub async fn run(
         //
             Ok(message) = broadcast_channel_receiver.recv() => {
                 match message {
-                    SaitoMessage::MempoolNewBlock { hash: _hash } => {
+                    SaitoMessage::NetworkNewBlock { hash: _hash } => {
                         println!("Blockchain aware network has received new block! -- we might use for this congestion tracking");
                     },
                     _ => {},

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -26,9 +26,11 @@ pub enum SaitoMessage {
     BlockchainAddBlockFailure { hash: SaitoHash },
     // broadcast when the miner finds a golden ticket
     MinerNewGoldenTicket { ticket: GoldenTicket },
-    // broadcast when the mempool produces a new block
-    MempoolNewBlock { hash: SaitoHash },
-    // broadcast when the mempool adds a new transaction
+    // broadcast when the blockchain wants to broadcast a block to peers
+    NetworkNewBlock { hash: SaitoHash },
+    // TODO this is unused and it's unclear when this will be done, fill
+    // this in when the message's use is clearer:
+    // broadcast when....?
     NetworkNewTransaction { transaction: Transaction },
 }
 

--- a/src/mempool.rs
+++ b/src/mempool.rs
@@ -261,7 +261,6 @@ pub async fn try_bundle_block(
     let can_bundle;
     {
         let mempool = mempool_lock.read().await;
-        info!("got mempool_lock");
         can_bundle = mempool
             .can_bundle_block(blockchain_lock.clone(), current_timestamp)
             .await;

--- a/src/networking/peer.rs
+++ b/src/networking/peer.rs
@@ -457,6 +457,7 @@ impl SaitoPeer {
                 }
             }
             "SNDBLKHD" => {
+                println!("handle_peer_command SNDBLKHD");
                 let send_block_head_message =
                     SendBlockHeadMessage::deserialize(api_message.get_message_data());
                 send_block_head_message.get_block_hash();


### PR DESCRIPTION
To try this, from one repo do: cargo run -- --spammer

This should give you blocks and Warp should start listening for socket connections.

if you want to start over, do: rm data/blocks/*.sai

From another repo, do: cargo run -- --config=config2.yml --password=asdf

This will try to connect to the peer specified in config2.yml(which is the default port which we ran above with cargo run).

The 2nd node should connect and sync itself with the first node, then when the first node makes a block, we want the NetworkNewBlock message to trigger a SNDBLKHD API message and to 2nd node which should then do a REQBLOCK back to the first node.