### PR TITLE
feat: init tests suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -667,6 +667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +868,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0f7efb804ec95e33db9ad49e4252f049e37e8b0a4652e3cd61f7999f2eff7f"
+dependencies = [
+ "ctor",
+ "ghost",
+ "inventory-impl",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75c094e94816723ab936484666968f5b58060492e880f3c8d00489a1e244fa51"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1662,6 +1695,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hex",
+ "inventory",
  "lazy_static",
  "log",
  "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,9 @@ warp = "0.3.1"
 criterion = "0.3"
 ctor = "0.1.21"
 env_logger = "0.9.0"
+inventory = "0.1.10"
+
+[[test]]
+name = "ts"
+path = "ts/main.rs"
+harness = false

--- a/ts/main.rs
+++ b/ts/main.rs
@@ -1,0 +1,22 @@
+pub mod tests;
+use tests::TestsSuite;
+
+fn setup() {
+    println!("----------------- Setup -----------------")
+}
+
+fn teardown() {
+    println!("----------------- Teardown -----------------")
+}
+fn main() {
+    // Setup test env
+    setup();
+
+    // Run test cases
+    for t in inventory::iter::<TestsSuite> {
+        (t.test_sth)()
+    }
+
+    // Teardown test env
+    teardown();
+}

--- a/ts/tests/first_test.rs
+++ b/ts/tests/first_test.rs
@@ -1,0 +1,10 @@
+use super::TestsSuite;
+
+fn first_test() {
+    println!("Running the first test")
+}
+
+inventory::submit!(TestsSuite {
+    name: "first",
+    test_sth: first_test
+});

--- a/ts/tests/mod.rs
+++ b/ts/tests/mod.rs
@@ -1,0 +1,9 @@
+pub mod first_test;
+
+#[derive(Debug)]
+pub struct TestsSuite {
+    pub name: &'static str,
+    pub test_sth: fn(),
+}
+
+inventory::collect!(TestsSuite);


### PR DESCRIPTION
I jump into this idea because we’re going to build all our test cases into a single crate.
By default, rust will compile each of `#[test]` labeled functions into its own binary crates (with its own main()) then executes it as part of the test.
This one is just a first step to remove `--test-threads=1` from `cargo test`.
I will add some configuration scripts for this. 
In the meantime, lets see what I have in it.
How to use: `cargo test ts`
