### PR TITLE
fix: Other removed from TryFromByte enums

### DIFF
--- a/src/slip.rs
+++ b/src/slip.rs
@@ -29,7 +29,6 @@ pub enum SlipType {
     StakerDeposit,
     StakerWithdrawalPending,
     StakerWithdrawalStaking,
-    Other, // need more than one value for TryFromBytes
 }
 
 #[serde_with::serde_as]

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -37,7 +37,6 @@ pub enum TransactionType {
     Vip,
     StakerDeposit,
     StakerWithdrawal,
-    Other,
     Issuance,
 }
 


### PR DESCRIPTION
These were needed when we only had Normal and Other types because TryFromByte required at least 2 fields in the enum. They are no longer needed.