### PR TITLE
feat: graceful shutdown warp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /src/data
 *.swp
 .idea/
+.vscode/

--- a/src/networking/mod.rs
+++ b/src/networking/mod.rs
@@ -125,3 +125,4 @@ pub mod handlers;
 pub mod message_types;
 pub mod network;
 pub mod peer;
+pub mod signals;

--- a/src/networking/network.rs
+++ b/src/networking/network.rs
@@ -26,6 +26,7 @@ use warp::{Filter, Rejection};
 
 use super::message_types::send_block_head_message::SendBlockHeadMessage;
 use super::peer::{PeerSetting, OUTBOUND_PEER_CONNECTIONS_GLOBAL, PEERS_DB_GLOBAL};
+use super::signals::signal_for_shutdown;
 
 use config::Config;
 
@@ -192,7 +193,7 @@ impl Network {
                                 }
                             }
                             Err(error) => {
-                                error!("Error reading from peer socket {}", error);
+                                error!("Error reading from peer socket {:?}", error);
                                 let peers_db_global = PEERS_DB_GLOBAL.clone();
                                 let mut peer_db = peers_db_global.write().await;
                                 let peer = peer_db.get_mut(&connection_id).unwrap();
@@ -204,7 +205,7 @@ impl Network {
                 Network::handshake_and_synchronize_chain(&connection_id, wallet_lock).await;
             }
             Err(error) => {
-                error!("Error connecting to peer {}", error);
+                error!("Error connecting to peer {:?}", error);
                 let mut peer_db = peers_db_global.write().await;
                 let peer = peer_db.get_mut(&connection_id).unwrap();
                 peer.set_is_connected_or_connecting(false).await;
@@ -314,7 +315,9 @@ impl Network {
                 self.blockchain_lock.clone(),
             ));
         println!("Listening for HTTP on port {}", port);
-        warp::serve(routes).run((host, port)).await;
+        let (_, server) =
+            warp::serve(routes).bind_with_graceful_shutdown((host, port), signal_for_shutdown());
+        server.await;
         Ok(())
     }
     // connects to any peers configured in our peers list. Opens a socket, does handshake, sychronizes, etc.

--- a/src/networking/signals.rs
+++ b/src/networking/signals.rs
@@ -1,0 +1,25 @@
+use tokio::signal;
+
+#[cfg(target_os = "unix")]
+pub async fn signal_for_shutdown() {
+    let mut interrupt_signal = signal::unix::signal(signal::unix::SignalKind::interrupt())
+        .expect("Error setting up interrupt signal");
+
+    let mut terminate_signal = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .expect("Error setting up terminate signal");
+
+    let mut quit_signal = signal::unix::signal(signal::unix::SignalKind::quit())
+        .expect("Error setting up quit signal");
+
+    tokio::select! {
+        _ = signal::ctrl_c() => (),
+        _ = interrupt_signal.recv() => (),
+        _ = terminate_signal.recv() => (),
+        _ = quit_signal.recv() => (),
+    }
+}
+
+#[cfg(not(target_os = "unix"))]
+pub async fn signal_for_shutdown() {
+    signal::ctrl_c().await.ok();
+}


### PR DESCRIPTION
The warp port does not shutdown properly when we issue interrupt signal to the binary. Therefore, I used [this warp function](https://docs.rs/warp/0.3.1/warp/struct.Server.html#method.bind_with_graceful_shutdown) for graceful shutdown feature.