### PR TITLE
feat: upgrade to latest Rust edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Stephen Peterkins <stephen@saito.tech>",
     "David Lancashire <david@saito.tech>"
 ]
-edition = "2018"
+edition = "2021"
 default-run = "saito_rust"
 
 


### PR DESCRIPTION
Rust language is not fully mature yet, we should keep growing along with its ecosystem. 
The upgrade only helps us benefit more from the language's support community, some fixes have also been applied in the new version. 
Follow this [guide](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html)

Re-built & all tested passed. 