### PR TITLE
docs: remove outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Please have a look at our [contributing guidelines](CONTRIBUTING.md) before you 
 ## Documentation
 
 - https://saitotech.github.io/saito-rust/saito_rust/index.html
-- [Architecture doc](ARCHITECTURE.md)
 
 ### Deps
 
@@ -100,8 +99,7 @@ Publish certain rust functionalities (as bin) as a npm package
 - https://github.com/EverlastingBugstopper/binary-install
 
 ## TODO
+
 Casual list of suggestions on improvements:
 
-[] routing hops currently contain two publickeys and one signature. we can remove "from" because it is contextually available (from the sender of the first transaction, and then the *to* field. We should also be able to reduce the signatures by switching to a different/commutive signature. This would magnificently remove the size of our transactions and shrink blocksize as well.
-
-
+[] routing hops currently contain two publickeys and one signature. we can remove "from" because it is contextually available (from the sender of the first transaction, and then the _to_ field. We should also be able to reduce the signatures by switching to a different/commutive signature. This would magnificently remove the size of our transactions and shrink blocksize as well.


### PR DESCRIPTION
[#84](https://github.com/SaitoTech/saito-rust/pull/84) removed the architecture-markdown file but not the link to it.

Also minor formatting changes.